### PR TITLE
Add Fabric: FHIR data fabric over the HIS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. new push to an open PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Fabric: full unit test suite ────────────────────────────────────────────
+  fabric:
+    name: fabric — pytest (py3.12)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: fabric
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: fabric/requirements-dev.txt
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+.eggs/
+.venv/
+venv/
+env/
+.env
+.env.*
+!.env.example
+*.log
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Docker
+*.override.yml

--- a/deployments/docker-compose.fabric.yml
+++ b/deployments/docker-compose.fabric.yml
@@ -1,0 +1,61 @@
+# Keep the same project name as docker-compose.yml so the two -f files merge into
+# one stack (see the note there).
+name: hospilot-internal
+
+services:
+
+  # ── Fabric (FHIR ingestion + HIS connectors + Kafka publisher) ─────────────
+  fabric:
+    build:
+      context: ../fabric
+      dockerfile: ../deployments/fabric.Dockerfile
+    ports:
+      - "8002:8001"
+    volumes:
+      - ../fabric/src:/app/src
+    env_file:
+      - ../fabric/.env
+    environment:
+
+      # Inside the compose network Kafka is reachable at kafka:9092, not localhost
+
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    depends_on:
+      kafka:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - hospilot-net
+
+  # ── Kafka (KRaft mode, single node — no Zookeeper) ────────────────────────
+  kafka:
+    image: apache/kafka:3.7.0
+    hostname: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: ["CMD", "/opt/kafka/bin/kafka-broker-api-versions.sh", "--bootstrap-server", "kafka:9092"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    networks:
+      - hospilot-net
+
+networks:
+  hospilot-net:
+    name: hospilot-net

--- a/deployments/fabric.Dockerfile
+++ b/deployments/fabric.Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src/
+
+EXPOSE 8001
+
+# src/ is the import root (config, api.*, fhirgw.* resolve from there)
+CMD ["uvicorn", "main:app", "--app-dir", "src", "--host", "0.0.0.0", "--port", "8001"]

--- a/fabric/.env.example
+++ b/fabric/.env.example
@@ -1,0 +1,66 @@
+# Hospilot-Fabric configuration — copy to `fabric/.env` and fill in.
+#
+# Every var below maps to a field on `Settings` in src/config.py; the values here
+# are that file's defaults (safe for local dev) or placeholders where a real
+# upstream is required. Anything you leave out falls back to the default in code.
+
+# ── Upstream: the HIS/DB FHIR API (what Fabric calls and transforms) ──────────
+# The real hospital system — never provisioned by this repo. Fabric only ever
+# calls it over HTTP.
+EHR_FHIR_BASE_URL=http://localhost:3001/fhir
+EHR_FHIR_API_KEY=
+
+# ── Upstream: the HIS/DB plain-REST financial API ─────────────────────────────
+# Normally the same host as above on a different path. The OT / ambulance /
+# appointment REST base and the initial-sync base are both derived from this
+# (see db_rest_base_url / sync_api_base_url in src/config.py).
+# Key falls back to EHR_FHIR_API_KEY when blank.
+FINANCIAL_API_BASE_URL=http://localhost:3001/api/financial
+FINANCIAL_API_KEY=
+
+# ── Downstream: Fabric's own auth (main app → Fabric) ─────────────────────────
+# Blank disables Fabric's auth entirely. Set this in any shared environment.
+FABRIC_API_KEY=
+
+# ── Identity (used only when minting identifier systems for FHIR writes) ──────
+FHIR_BASE_URL=http://localhost:8002/fhir
+EHR_SOURCE=hospilot
+
+# ── Ingest mode: how Fabric learns about upstream changes ─────────────────────
+#   change_api (default) — poll the HIS FHIR $changed-resources change feed
+#   polling              — no change feed upstream; Fabric polls each per-resource
+#                          API and publishes a field-level diff (see diff_poller.py)
+#   kafka                — as change_api for reads, but approved writes are PUSHED
+#                          to KAFKA_WRITE_TOPIC instead of pulled via $pending-changes
+INTEGRATION_MODE=change_api
+
+# ── Kafka: Fabric publishes data-change events to the main app ────────────────
+# Blank bootstrap servers disable BOTH publishing and the change poller (dev default).
+# In the compose stack this is overridden to kafka:9092.
+KAFKA_BOOTSTRAP_SERVERS=
+KAFKA_TOPIC_PREFIX=hospilot.data
+KAFKA_CLIENT_ID=hospilot-fabric
+KAFKA_ACK_TOPIC=hospilot.sync.ack
+KAFKA_WRITE_TOPIC=hospilot.sync.write
+POLL_INTERVAL_MS=10000
+WRITE_DRAIN_INTERVAL_MS=1000
+# Soft lock on an in-flight write snapshot: if the HIS doesn't $confirm within this
+# window the lock expires and those changes are re-offered on the next pull.
+SNAPSHOT_LOCK_TIMEOUT_MS=60000
+
+# ── Polling-mode cadences (ms) — only read when INTEGRATION_MODE=polling ──────
+# Defaults reflect clinical volatility: beds flip fast, labs/tasks are slower,
+# the keyset-paginated lab_result table gets the slowest cadence.
+POLL_INTERVAL_BED_MS=5000
+POLL_INTERVAL_ADMISSION_MS=10000
+POLL_INTERVAL_VISIT_MS=10000
+POLL_INTERVAL_LAB_ORDER_MS=15000
+POLL_INTERVAL_TASK_MS=15000
+POLL_INTERVAL_LAB_RESULT_MS=30000
+POLL_INTERVAL_REST_MS=10000
+
+# ── App ──────────────────────────────────────────────────────────────────────
+APP_ENV=development
+# Comma-separated; `*` allows any origin (dev only).
+CORS_ORIGINS=*
+UPSTREAM_TIMEOUT=20.0

--- a/fabric/pyproject.toml
+++ b/fabric/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "hospilot-fabric"
+version = "0.1.0"
+description = "FHIR-compliant data fabric over the hospilot DB (FHIR R5 + normalized REST)."
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi==0.115.0",
+    "uvicorn[standard]==0.30.6",
+    "httpx==0.27.2",
+    "pydantic==2.9.2",
+    "pydantic-settings==2.5.2",
+    "python-dotenv==1.0.1",
+    "python-dateutil==2.9.0.post0",
+    "fhir.resources==8.2.0",
+    "fhir-core==1.1.8",
+    # Transitive, but MUST be pinned: fhir-core 1.1.8 imports `SLOTS` from
+    # annotated_types, which 0.8.0 removed.
+    "annotated-types==0.7.0",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/fabric/requirements-dev.txt
+++ b/fabric/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.3

--- a/fabric/requirements.txt
+++ b/fabric/requirements.txt
@@ -1,0 +1,18 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+httpx==0.27.2
+pydantic==2.9.2
+pydantic-settings==2.5.2
+python-dotenv==1.0.1
+python-dateutil==2.9.0.post0
+
+# FHIR R5 (5.0.0) resource models — the transformation core
+fhir.resources==8.2.0
+fhir-core==1.1.8
+# Transitive, but MUST be pinned: fhir-core 1.1.8 imports `SLOTS` from
+# annotated_types, which 0.8.0 removed. Unpinned, pip resolves 0.8.0 and every
+# fhir.resources import fails at collection time.
+annotated-types==0.7.0
+
+# Kafka — Fabric publishes data-change events for hospilot-backend to consume
+aiokafka==0.11.0

--- a/fabric/src/api/agents.py
+++ b/fabric/src/api/agents.py
@@ -1,0 +1,105 @@
+"""Agent-facing endpoints: OT, Ambulance, Appointments.
+
+These endpoints are designed for careros-hospilot-backend agents that need
+to query operating-theatre status, ambulance fleet, and appointment data.
+"""
+
+from fastapi import APIRouter, Query
+from typing import Optional
+
+from service import ambulance as amb_svc
+from service import appointments as appt_svc
+from service import ot as ot_svc
+from service import writes as writes_svc
+
+router = APIRouter()
+
+
+# ── OT ───────────────────────────────────────────────────────────────────────
+
+@router.get("/ot/rooms", summary="List all OT rooms with capacity and equipment")
+async def get_ot_rooms():
+    return await ot_svc.rooms()
+
+
+@router.get("/ot/room-status", summary="Live surgery status for each OT room")
+async def get_ot_room_status():
+    return await ot_svc.room_status()
+
+
+@router.get("/ot/surgery-schedule", summary="Scheduled surgeries with staff and patient details")
+async def get_surgery_schedule():
+    return await ot_svc.surgery_schedule()
+
+
+@router.get("/ot/equipment-usage", summary="OT equipment usage records (empty if none)")
+async def get_equipment_usage():
+    return await ot_svc.equipment_usage()
+
+
+@router.get("/ot/surgeries", summary="All surgeries with pre/post-op notes and outcomes")
+async def get_surgeries():
+    return await ot_svc.surgeries()
+
+
+@router.post(
+    "/ot/surgery-schedule/{surgery_id}/reschedule",
+    summary="Reschedule a surgery to a new theatre slot (queued as a pending change)",
+    status_code=202,
+)
+async def reschedule_surgery(surgery_id: str, body: dict):
+    fields = {k: body.get(k) for k in
+              ("scheduled_date", "scheduled_start_time", "scheduled_end_time", "ot_room_id", "status")}
+    return await writes_svc.reschedule_surgery(surgery_id, fields)
+
+
+# ── Ambulance ────────────────────────────────────────────────────────────────
+
+@router.get("/ambulances", summary="Ambulance fleet with live status, location, and ETA")
+async def get_ambulance_fleet():
+    return await amb_svc.fleet()
+
+
+# ── Appointments ─────────────────────────────────────────────────────────────
+
+@router.get("/appointments", summary="List appointments with optional filters")
+async def get_appointments(
+    patient_id: Optional[str] = Query(None, description="Filter by patient ID"),
+    provider_id: Optional[str] = Query(None, description="Filter by provider/doctor ID"),
+    department_id: Optional[str] = Query(None, description="Filter by department ID"),
+    status: Optional[str] = Query(None, description="Filter by appointment status"),
+    date: Optional[str] = Query(None, description="Filter by appointment date (YYYY-MM-DD)"),
+):
+    return await appt_svc.list_all(
+        patient_id=patient_id,
+        provider_id=provider_id,
+        department_id=department_id,
+        status=status,
+        date=date,
+    )
+
+
+@router.post("/appointments", summary="Create a new appointment", status_code=201)
+async def create_appointment(body: dict):
+    return await appt_svc.create(body)
+
+
+@router.get("/appointments/slots", summary="List available appointment slots")
+async def get_appointment_slots(
+    provider_id: Optional[str] = Query(None, description="Filter by provider ID"),
+    date: Optional[str] = Query(None, description="Filter by slot date (YYYY-MM-DD)"),
+    specialization: Optional[str] = Query(None, description="Filter by specialization"),
+):
+    return await appt_svc.slots(
+        provider_id=provider_id,
+        date=date,
+        specialization=specialization,
+    )
+
+
+@router.patch(
+    "/appointments/slots/{slot_id}/book",
+    summary="Book an appointment slot (mark as booked)",
+)
+async def book_slot(slot_id: str):
+    return await appt_svc.book_slot(slot_id)

--- a/fabric/src/api/fhir.py
+++ b/fabric/src/api/fhir.py
@@ -1,0 +1,153 @@
+"""FHIR R5 snapshot API — the two-phase, soft-locked pending-changes exchange.
+
+The DB drains queued writes in three steps:
+
+  1. GET  /fhir/Bundle/$pending-changes
+        Mints a snapshot_id, resolves deferred ids, and returns the queued changes as a
+        FHIR R5 transaction Bundle (one entry per change, `fullUrl` = change id). The
+        snapshot becomes the single in-flight one; re-pulling returns the SAME snapshot.
+
+  2. POST /fhir/Bundle/$pending-changes/$acknowledge   {snapshot_id}
+        Receipt — the DB has durably received the Bundle. Fabric marks it locked (soft
+        lock held). The queue is NOT cleared here.
+
+  3. POST /fhir/Bundle/$pending-changes/$confirm
+        {snapshot_id, results: [{change_id, status, reason?, assigned_id?}]}
+        The DB reports accepted/rejected per change. Fabric publishes one ack event per
+        change to Kafka (so the backend reconciles Redis + releases its lock), then
+        clears the snapshot (releases the soft lock).
+
+If the DB never confirms within SNAPSHOT_LOCK_TIMEOUT_MS, the lock expires and the
+changes are re-offered on the next pull (at-least-once). Rejected changes are published
+as "rejected" and dropped — no retry.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from config import settings
+from fhirgw.bundle import build_snapshot_bundle, resolve_changes
+from ingest import kafka_publisher as kafka
+from service.change_store import SnapshotError, get_change_store, now_iso
+
+logger = logging.getLogger("fhir_api")
+
+
+def _guard_pull_disabled() -> None:
+    """In kafka write mode the DB no longer pulls — proposals are pushed to
+    `hospilot.sync.write` by the write publisher. Reject the pull endpoints with 409 so
+    they can't race the publisher loop for the same in-memory queue. Guarded on
+    kafka.enabled() too, so the kafka-mode-but-Kafka-disabled dev case keeps the pull
+    active as the only write exit."""
+    if settings.kafka_mode and kafka.enabled():
+        raise HTTPException(
+            status_code=409,
+            detail=("pull disabled: INTEGRATION_MODE=kafka — proposals are pushed to "
+                    f"{settings.kafka_write_topic}; consume that topic instead"),
+        )
+
+
+router = APIRouter(dependencies=[Depends(_guard_pull_disabled)])
+
+_FHIR_MEDIA_TYPE = "application/fhir+json"
+
+_EMPTY_BUNDLE = {"resourceType": "Bundle", "type": "transaction", "entry": []}
+
+
+class AckBody(BaseModel):
+    snapshot_id: str
+
+
+class ChangeResult(BaseModel):
+    change_id: str
+    status: str                       # "accepted" | "rejected"
+    reason: str | None = None
+    assigned_id: str | None = None    # id the DB assigned to a POST-created resource
+
+
+class ConfirmBody(BaseModel):
+    snapshot_id: str
+    results: list[ChangeResult]
+
+
+@router.get("/fhir/Bundle/$pending-changes")
+async def get_pending_changes():
+    store = get_change_store()
+    # Idempotent re-pull: an in-flight (offered/locked) snapshot is returned unchanged,
+    # unless it has expired (its changes are then re-queued for a fresh offer).
+    snap = await store.current_inflight(settings.snapshot_lock_timeout_s)
+    if snap is None:
+        pending = await store.drain_pending()
+        resolved = await resolve_changes(pending)        # async DB lookups, outside the store lock
+        snap = await store.commit_inflight(resolved)
+        if snap is None:
+            return JSONResponse(content=_EMPTY_BUNDLE, media_type=_FHIR_MEDIA_TYPE)
+    bundle = build_snapshot_bundle(snap.changes, snap.snapshot_id)
+    return JSONResponse(content=bundle, media_type=_FHIR_MEDIA_TYPE)
+
+
+@router.post("/fhir/Bundle/$pending-changes/$acknowledge")
+async def acknowledge_snapshot(body: AckBody):
+    """Receipt: the DB has durably received the snapshot. Holds the soft lock."""
+    try:
+        await get_change_store().mark_locked(body.snapshot_id)
+    except SnapshotError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    return {"ok": True, "snapshot_id": body.snapshot_id, "state": "locked"}
+
+
+@router.post("/fhir/Bundle/$pending-changes/$confirm")
+async def confirm_snapshot(body: ConfirmBody):
+    """The DB reports accepted/rejected per change. Publish acks, then release the lock.
+
+    On a publish failure the snapshot is left locked and a 502 is returned so the DB can
+    retry $confirm (the backend ack consumer is idempotent)."""
+    store = get_change_store()
+    try:
+        changes = await store.inflight_changes(body.snapshot_id)
+    except SnapshotError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    by_id = {c.change_id: c for c in changes}
+    ts = now_iso()
+    published = 0
+    failures: list[str] = []
+    for result in body.results:
+        change = by_id.get(result.change_id)
+        if change is None:
+            logger.warning("$confirm: unknown change_id %s for snapshot %s",
+                           result.change_id, body.snapshot_id)
+            continue
+        record_id = result.assigned_id or change.record_id
+        try:
+            await kafka.publish_ack(
+                snapshot_id=body.snapshot_id,
+                change_id=change.change_id,
+                entity=change.entity,
+                record_id=record_id,
+                change_type=change.change_type,
+                status=result.status,
+                reason=result.reason,
+                ts=ts,
+            )
+            published += 1
+        except Exception as exc:  # delivery failure — keep lock, let the DB retry
+            failures.append(change.change_id)
+            logger.error("✗ ack publish %s/%s failed: %s",
+                         change.entity, record_id, str(exc)[:160])
+
+    if failures:
+        # Lock NOT released — the same snapshot stays in flight so the DB can retry
+        # $confirm with the same snapshot_id (the ack consumer is idempotent).
+        raise HTTPException(
+            status_code=502,
+            detail=f"{len(failures)} ack publish(es) failed; snapshot kept locked for retry",
+        )
+
+    await store.release(body.snapshot_id)
+    logger.info("→ snapshot %s confirmed: %d ack(s) published & lock released",
+                body.snapshot_id, published)
+    return {"ok": True, "snapshot_id": body.snapshot_id, "published": published}

--- a/fabric/src/api/normalized.py
+++ b/fabric/src/api/normalized.py
@@ -1,0 +1,510 @@
+"""
+Normalized REST API — the face Fabric exposes to the main backend.
+
+Each route calls the service layer, which calls the DB's FHIR/financial APIs and
+transforms the responses into the plain dict shapes the agents already use. Reads
+are GET; writes are POST (translated to FHIR and sent to the DB). Errors are plain
+JSON (404 via HTTPException).
+
+Static sub-paths are declared before `/{id}` routes so they aren't shadowed.
+"""
+
+import logging
+from datetime import datetime, timezone, timedelta
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from clients import fhir_client as fc
+from service import clinical, financial, writes, transform as tx, lab as lab_svc, pharmacy as pharmacy_svc
+
+logger = logging.getLogger("normalized")
+router = APIRouter()
+
+
+async def _or_404(value, what: str):
+    if value is None:
+        raise HTTPException(status_code=404, detail=f"{what} not found")
+    return value
+
+
+# ─── beds ──────────────────────────────────────────────────────────────────────
+@router.get("/beds")
+async def beds():
+    return await clinical.beds()
+
+
+@router.get("/beds/available-icu")
+async def beds_available_icu():
+    return await clinical.available_icu_beds()
+
+
+@router.get("/beds/dirty")
+async def beds_dirty():
+    return await clinical.dirty_beds()
+
+
+@router.get("/beds/dirty-icu")
+async def beds_dirty_icu():
+    return await clinical.dirty_beds(icu_only=True)
+
+
+@router.get("/beds/postop")
+async def beds_postop():
+    return [b for b in await clinical.beds()
+            if not tx.is_icu_bed(b) and b.get("status") == "Available"]
+
+
+@router.get("/beds/summary")
+async def beds_summary():
+    return await clinical.beds_summary()
+
+
+@router.get("/beds/{bed_id}")
+async def bed(bed_id: str):
+    rid = bed_id if bed_id.startswith("bed-") else f"bed-{bed_id}"   # DB ids are bed-{uuid}
+    loc = await fc.read_location(rid)
+    return await _or_404(tx.bed(loc) if loc else None, f"Bed {bed_id}")
+
+
+class BedStatus(BaseModel):
+    status: str
+
+
+@router.post("/beds/{bed_id}/status")
+async def set_bed_status(bed_id: str, body: BedStatus):
+    await writes.update_bed_status(bed_id, body.status)
+    return {"ok": True, "id": bed_id, "status": body.status}
+
+
+# ─── admissions ─────────────────────────────────────────────────────────────────
+@router.get("/admissions")
+async def admissions():
+    return await clinical.all_admissions()
+
+
+@router.get("/admissions/icu")
+async def admissions_icu():
+    return await clinical.icu_admissions()
+
+
+@router.get("/admissions/non-icu")
+async def admissions_non_icu():
+    return await clinical.non_icu_admissions()
+
+
+@router.get("/admissions/with-wards")
+async def admissions_with_wards():
+    return await clinical.admissions_with_wards()
+
+
+@router.get("/admissions/discharge-eligible")
+async def admissions_discharge_eligible():
+    return [a for a in await clinical.all_admissions() if (a.get("status") in (None, "admitted"))]
+
+
+@router.get("/admissions/discharge-ready")
+async def admissions_discharge_ready():
+    return [a for a in await clinical.all_admissions() if a.get("discharge_ready")]
+
+
+@router.get("/admissions/discharge-ready-count")
+async def admissions_discharge_ready_count():
+    return {"count": await clinical.discharge_ready_count()}
+
+
+@router.get("/admissions/discharge-horizon")
+async def admissions_discharge_horizon(hours: int = Query(24)):
+    cutoff = (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
+    n = sum(1 for a in await clinical.all_admissions()
+            if a.get("discharge_ready") or (a.get("expected_discharge_at") or "") and (a["expected_discharge_at"] <= cutoff))
+    return {"hours": hours, "count": n}
+
+
+class TransferPending(BaseModel):
+    ids: list[str]
+
+
+@router.post("/admissions/transfer-pending")
+async def admissions_transfer_pending(body: TransferPending):
+    await writes.set_admissions_transfer_pending(body.ids)
+    return {"ok": True, "count": len(body.ids)}
+
+
+@router.get("/admissions/{admission_id}")
+async def admission(admission_id: str):
+    rid = admission_id if admission_id.startswith("ipd-") else f"ipd-{admission_id}"   # DB ids are ipd-{uuid}
+    enc = await fc.read_encounter(rid)
+    return await _or_404(tx.admission(enc) if enc else None, f"Admission {admission_id}")
+
+
+class DischargeReady(BaseModel):
+    ready: bool
+    blocked_reason: str | None = None
+
+
+@router.post("/admissions/{admission_id}/discharge-ready")
+async def set_discharge_ready(admission_id: str, body: DischargeReady):
+    await writes.update_discharge_ready(admission_id, body.ready, body.blocked_reason)
+    return {"ok": True, "id": admission_id, "ready": body.ready}
+
+
+# ─── vitals ─────────────────────────────────────────────────────────────────────
+@router.get("/vitals/latest")
+async def vitals_latest(patient: str = Query(...)):
+    return await clinical.latest_vitals(patient)
+
+
+@router.get("/vitals/critical")
+async def vitals_critical():
+    return await clinical.critical_vitals()
+
+
+@router.get("/vitals/observations/{observation_id}")
+async def vital_observation(observation_id: str):
+    obs = await fc.read_observation(observation_id)
+    return await _or_404(obs, f"Observation {observation_id}")
+
+
+@router.post("/vitals/{vital_id}/critical")
+async def flag_vital_critical(vital_id: str):
+    await writes.flag_critical_vital(vital_id)
+    return {"ok": True, "id": vital_id, "is_critical": True}
+
+
+# ─── visits / ER ────────────────────────────────────────────────────────────────
+@router.get("/visits/er")
+async def visits_er():
+    return await clinical.er_visits()
+
+
+@router.get("/visits/untriaged")
+async def visits_untriaged():
+    return [v for v in await clinical.er_visits() if v.get("triage_score") is None]
+
+
+@router.get("/er/pressure")
+async def er_pressure():
+    return await clinical.er_pressure()
+
+
+class BulkTriage(BaseModel):
+    items: list[dict]
+
+
+@router.post("/visits/triage/bulk")
+async def visits_triage_bulk(body: BulkTriage):
+    await writes.bulk_set_triage_scores(body.items)
+    return {"ok": True, "count": len(body.items)}
+
+
+class TriageScore(BaseModel):
+    score: int
+
+
+@router.post("/visits/{visit_id}/triage")
+async def set_triage(visit_id: str, body: TriageScore):
+    await writes.set_triage_score(visit_id, body.score)
+    return {"ok": True, "id": visit_id, "score": body.score}
+
+
+# ─── nursing tasks ──────────────────────────────────────────────────────────────
+@router.get("/tasks/incomplete")
+async def tasks_incomplete():
+    return await clinical.incomplete_tasks()
+
+
+@router.get("/tasks/overdue")
+async def tasks_overdue():
+    return await clinical.overdue_tasks()
+
+
+@router.get("/tasks/completed-count")
+async def tasks_completed_count(admission: str = Query(...)):
+    return {"admission_id": admission, "count": await clinical.completed_task_count(admission)}
+
+
+@router.get("/tasks")
+async def tasks(admission: str | None = Query(None)):
+    if admission:
+        return await clinical.nursing_tasks_for(admission)
+    return await clinical.incomplete_tasks()
+
+
+# ─── labs ───────────────────────────────────────────────────────────────────────
+@router.get("/labs/orders")
+async def lab_orders_all():
+    return await clinical.lab_orders()
+
+
+@router.get("/labs/orders/pending")
+async def lab_orders_pending():
+    return await clinical.lab_orders()
+
+
+@router.get("/labs/results")
+async def lab_results(patient: str | None = Query(None), test_code: str | None = Query(None)):
+    return await clinical.lab_results(patient_token=patient, test_code=test_code)
+
+
+# ─── departments / patients ──────────────────────────────────────────────────────
+@router.get("/departments")
+async def departments():
+    return await clinical.departments()
+
+
+@router.get("/patients/tokens")
+async def patient_tokens():
+    return await clinical.patient_tokens()
+
+
+@router.get("/patients")
+async def patients(ids: str = Query(..., description="comma-separated patient tokens")):
+    """{token: {first_name, last_name, uhid, ...}} — replaces db.hasura.get_patient_names."""
+    toks = [t.strip() for t in ids.split(",") if t.strip()]
+    return await clinical.patient_names(toks)
+
+
+@router.get("/patients/by-mobile")
+async def patient_by_mobile(mobile: str = Query(..., description="Phone number — any format; normalised to last 10 digits")):
+    return await clinical.patient_by_mobile(mobile)
+
+
+@router.get("/patients/{token}")
+async def patient(token: str):
+    return await _or_404(await clinical.patient(token), f"Patient {token}")
+
+
+# ─── discharge summaries ────────────────────────────────────────────────────────
+class AINote(BaseModel):
+    note: str
+
+
+@router.post("/discharge-summaries/{admission_id}/ai-note")
+async def set_ai_note(admission_id: str, body: AINote):
+    await writes.set_ai_discharge_note(admission_id, body.note)
+    return {"ok": True, "admission_id": admission_id}
+
+
+# ─── financial (DB's plain-REST financial API, passed through) ───────────────────
+@router.get("/financial/invoices")
+async def fin_invoices(
+    payment_status: str | None = None,
+    patient: str | None = None,
+    invoice_type: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+):
+    return await financial.invoices(
+        payment_status=payment_status, patient=patient, invoice_type=invoice_type,
+        limit=limit, offset=offset,
+    )
+
+
+@router.get("/financial/invoices/{invoice_id}/line-items")
+async def fin_invoice_line_items(invoice_id: str):
+    return await financial.invoice_line_items(invoice_id)
+
+
+@router.get("/financial/claims")
+async def fin_claims(
+    status: str | None = None,
+    patient: str | None = None,
+    visit_id: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+):
+    return await financial.claims(
+        status=status, patient=patient, visit_id=visit_id, limit=limit, offset=offset,
+    )
+
+
+@router.get("/financial/claims/{claim_id}/line-items")
+async def fin_claim_line_items(claim_id: str):
+    return await financial.claim_line_items(claim_id)
+
+
+@router.get("/financial/claims/{claim_id}/history")
+async def fin_claim_history(claim_id: str):
+    return await financial.claim_history(claim_id)
+
+
+@router.get("/financial/claims/{claim_id}/queries")
+async def fin_claim_queries(claim_id: str):
+    return await financial.claim_queries(claim_id)
+
+
+@router.get("/financial/payments")
+async def fin_payments():
+    return await financial.payments()
+
+
+@router.get("/financial/payments/{payment_id}/entries")
+async def fin_payment_entries(payment_id: str):
+    return await financial.payment_entries(payment_id)
+
+
+# ─── patient registration ─────────────────────────────────────────────────────
+# In-memory store for pending registration requests (TTL handled by backend's
+# 24h reaper; process restart is safe — backend re-sends on timeout).
+import re as _re
+import uuid as _uuid
+from datetime import datetime as _dt, timezone as _tz
+
+_pending_registrations: dict[str, dict] = {}
+
+
+class _RegisterRequest(BaseModel):
+    mobile: str
+    name_hint: str | None = None
+    session_id: str
+    source: str = "patient_verification_agent"
+
+
+@router.post("/patients/register", status_code=202)
+async def register_patient(body: _RegisterRequest):
+    """Receive a registration request from the backend, store it as pending, and
+    return immediately. The actual patient creation is manual (DB side worklist).
+    The diff poller detects the new patient and publishes hospilot.data.patient."""
+    digits = _re.sub(r"\D", "", body.mobile)[-10:]
+    request_id = f"reg_{_uuid.uuid4().hex[:8]}"
+    _pending_registrations[request_id] = {
+        "request_id": request_id,
+        "mobile": digits,
+        "mobile_display": body.mobile,
+        "name_hint": body.name_hint,
+        "session_id": body.session_id,
+        "source": body.source,
+        "status": "pending",
+        "created_at": _dt.now(_tz.utc).isoformat(),
+    }
+    logger.info("patient registration pending  mobile=%s  session=%s  req=%s",
+                digits, body.session_id, request_id)
+    return {"request_id": request_id, "status": "pending"}
+
+
+@router.get("/patients/register/pending")
+async def pending_registrations():
+    """Pending patient registration requests — polled by the DB-side staff worklist."""
+    return list(_pending_registrations.values())
+
+
+@router.delete("/patients/register/{request_id}")
+async def complete_registration(request_id: str):
+    """Mark a registration request complete (called when staff confirm patient created)."""
+    entry = _pending_registrations.pop(request_id, None)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Registration request not found")
+    logger.info("patient registration completed  req=%s", request_id)
+    return {"request_id": request_id, "status": "completed"}
+
+
+@router.get("/financial/refunds")
+async def fin_refunds(invoice_id: str | None = None):
+    return await financial.refunds(invoice_id=invoice_id)
+
+
+@router.get("/financial/contracts")
+async def fin_contracts():
+    return await financial.contracts()
+
+
+@router.get("/financial/contracts/{contract_id}/rates")
+async def fin_contract_rates(contract_id: str):
+    return await financial.contract_rates(contract_id)
+
+
+@router.get("/financial/collections/{date}")
+async def fin_collections(date: str):
+    return await financial.collections(date)
+
+
+@router.get("/financial/reconciliation/{date}")
+async def fin_reconciliation(date: str):
+    return await financial.reconciliation(date)
+
+
+# ─── labs (extended) ─────────────────────────────────────────────────────────
+# /labs/orders/pending and /labs/results are already above (FHIR-backed via clinical.py).
+# The routes below are the additional lab agent endpoints.
+
+@router.get("/labs/samples")
+async def lab_samples():
+    return await lab_svc.samples()
+
+
+@router.get("/labs/analyzers")
+async def lab_analyzers():
+    return await lab_svc.analyzers()
+
+
+@router.get("/labs/qc-logs")
+async def lab_qc_logs(hours: int = Query(24)):
+    return await lab_svc.qc_logs(hours=hours)
+
+
+@router.get("/labs/reflex-rules")
+async def lab_reflex_rules():
+    return await lab_svc.reflex_rules()
+
+
+@router.get("/labs/validation-rules")
+async def lab_validation_rules():
+    return await lab_svc.validation_rules()
+
+
+@router.get("/labs/capacity")
+async def lab_capacity(days: int = Query(30)):
+    return await lab_svc.capacity_history(days=days)
+
+
+@router.get("/labs/critical-escalations")
+async def lab_critical_escalations():
+    return await lab_svc.critical_escalations()
+
+
+# ─── pharmacy ────────────────────────────────────────────────────────────────
+
+@router.get("/pharmacy/orders")
+async def pharmacy_orders():
+    return await pharmacy_svc.orders()
+
+
+@router.get("/pharmacy/orders/pending")
+async def pharmacy_orders_pending():
+    return await pharmacy_svc.pending_orders()
+
+
+@router.get("/pharmacy/orders/stat")
+async def pharmacy_orders_stat():
+    return await pharmacy_svc.stat_orders()
+
+
+@router.get("/pharmacy/inventory")
+async def pharmacy_inventory():
+    return await pharmacy_svc.inventory()
+
+
+@router.get("/pharmacy/dispensing-log")
+async def pharmacy_dispensing_log(hours: int = Query(8)):
+    return await pharmacy_svc.dispensing_log(hours=hours)
+
+
+@router.get("/pharmacy/interactions")
+async def pharmacy_interactions():
+    return await pharmacy_svc.interaction_rules()
+
+
+@router.get("/pharmacy/substitutions")
+async def pharmacy_substitutions():
+    return await pharmacy_svc.substitution_rules()
+
+
+@router.get("/pharmacy/controlled-log")
+async def pharmacy_controlled_log(hours: int = Query(24)):
+    return await pharmacy_svc.controlled_log(hours=hours)
+
+
+@router.get("/pharmacy/capacity")
+async def pharmacy_capacity(days: int = Query(30)):
+    return await pharmacy_svc.capacity_history(days=days)

--- a/fabric/src/api/sync.py
+++ b/fabric/src/api/sync.py
@@ -1,0 +1,67 @@
+"""Initial-sync endpoints exposed to the main backend.
+
+One-time, keyset-paginated full-table dumps used to populate Redis from scratch
+before the Kafka change feed takes over for incremental updates. Each Fabric
+endpoint forwards to the DB's matching /api/sync/<table>, passing the cursor /
+sync_id / limit through and returning the DB's pagination envelope unchanged.
+
+See docs/INITIAL_SYNC_INTEGRATION.md for the consumer contract.
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+from service import initial_sync
+
+router = APIRouter()
+logger = logging.getLogger("sync_api")
+
+
+@router.get("/sync/tables", summary="List the tables available for initial sync")
+async def sync_tables():
+    return {"tables": initial_sync.TABLES, "sources": initial_sync.TABLE_SOURCES}
+
+
+@router.get(
+    "/sync/{table}",
+    summary="Fetch one keyset-paginated page of a table for the initial Redis sync",
+)
+async def sync_table(
+    table: str,
+    limit: Optional[int] = Query(
+        None,
+        ge=1,
+        le=1000,
+        description="Rows per page. Clamped to [1, 1000] upstream. Default 200.",
+    ),
+    cursor: Optional[str] = Query(
+        None,
+        description="Opaque cursor from the previous response's pagination.next_cursor. Omit on the first call.",
+    ),
+    sync_id: Optional[str] = Query(
+        None,
+        description="Correlation id returned on the first call. Pass it back on every subsequent call.",
+    ),
+):
+    if not initial_sync.is_valid_table(table):
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": f"Unknown sync table '{table}'",
+                "valid_tables": initial_sync.TABLES,
+            },
+        )
+    try:
+        return await initial_sync.page(
+            table, limit=limit, cursor=cursor, sync_id=sync_id
+        )
+    except httpx.HTTPStatusError as exc:
+        # surface the DB's status + body (400 invalid cursor, 401, 500 DB error, ...)
+        detail = exc.response.json() if exc.response.content else str(exc)
+        raise HTTPException(status_code=exc.response.status_code, detail=detail)
+    except httpx.HTTPError as exc:
+        logger.warning("initial-sync upstream error table=%s: %s", table, str(exc)[:160])
+        raise HTTPException(status_code=502, detail="Initial-sync upstream unavailable")

--- a/fabric/src/clients/fhir_client.py
+++ b/fabric/src/clients/fhir_client.py
@@ -1,0 +1,313 @@
+"""HTTP client for the DB's FHIR R5 API (the upstream Fabric transforms).
+
+Fabric is the FHIR *client*. It GETs canonical FHIR R5 resources from the DB's
+FHIR server (`settings.ehr_fhir_base_url`) and hands the parsed `fhir.resources`
+models to the transform layer. For writes it sends FHIR back (PATCH/PUT).
+
+`_normalize` smooths over real-world R5 quirks so `fhir.resources` parses upstream
+payloads:
+  • naive datetimes (no timezone) → assume UTC (`…Z`)
+  • `Encounter.reason[].value` sent as an object → wrap in the R5 list
+  • resource-level `identifier` sent as an object → wrap in the R5 list
+  • `ServiceRequest.code` sent as a bare CodeableConcept → wrap as CodeableReference
+  • `Composition.subject`/`author` sent as a single object → wrap in the R5 list
+Unparseable resources are skipped (logged) so one bad row can't fail a census.
+"""
+
+import logging
+import re
+
+import httpx
+
+from config import settings
+from fhir.resources.encounter import Encounter
+from fhir.resources.location import Location
+from fhir.resources.observation import Observation
+from fhir.resources.organization import Organization
+from fhir.resources.patient import Patient
+from fhir.resources.task import Task
+from fhir.resources.servicerequest import ServiceRequest
+from fhir.resources.composition import Composition
+from fhir.resources.specimen import Specimen
+from fhir.resources.device import Device
+from fhir.resources.medicationrequest import MedicationRequest
+try:
+    from fhir.resources.inventoryitem import InventoryItem as _InventoryItem
+    InventoryItem = _InventoryItem
+except ImportError:
+    InventoryItem = None
+
+logger = logging.getLogger("fhir_client")
+
+_NAIVE_DT = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?$")  # no Z / offset
+
+
+def configured() -> bool:
+    return bool(settings.ehr_fhir_base_url)
+
+
+def _headers(extra: dict | None = None) -> dict:
+    h = {"Accept": "application/fhir+json"}
+    if settings.ehr_fhir_api_key:
+        h["Authorization"] = f"Bearer {settings.ehr_fhir_api_key}"
+    if extra:
+        h.update(extra)
+    return h
+
+
+def _normalize(node):
+    """Smooth over the upstream server's R5 deviations so fhir.resources parses."""
+    if isinstance(node, dict):
+        rt = node.get("resourceType")
+        reason = node.get("reason")
+        if isinstance(reason, list):
+            for r in reason:
+                if isinstance(r, dict) and isinstance(r.get("value"), dict):
+                    r["value"] = [r["value"]]
+        if rt:
+            if isinstance(node.get("identifier"), dict):
+                node["identifier"] = [node["identifier"]]
+            if rt == "ServiceRequest":
+                code = node.get("code")
+                if isinstance(code, dict) and "concept" not in code and "reference" not in code:
+                    node["code"] = {"concept": code}
+                node.pop("orderDetail", None)
+                # R5 requires ServiceRequest.subject; the DB currently omits it, which
+                # would make every lab order fail validation and get skipped. Inject a
+                # placeholder so the order still parses (patient_token stays empty until
+                # the DB adds subject = Patient/{patient_token}).
+                if not node.get("subject"):
+                    node["subject"] = {"display": "unknown"}
+            if rt == "Composition":
+                for fld in ("subject", "author"):
+                    if isinstance(node.get(fld), dict):
+                        node[fld] = [node[fld]]
+        return {k: _normalize(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_normalize(x) for x in node]
+    if isinstance(node, str) and _NAIVE_DT.match(node):
+        return node + "Z"
+    return node
+
+
+async def _get(path: str, params: dict | None = None) -> dict:
+    base = settings.ehr_fhir_base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.get(f"{base}/{path}", params=params, headers=_headers())
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _get_or_none(path: str) -> dict | None:
+    """GET a single resource, returning None on 404 (so a missing id is a clean
+    404 for the caller, not a 500)."""
+    try:
+        return await _get(path)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return None
+        raise
+
+
+async def _search(resource_type: str, params: dict) -> list[dict]:
+    bundle = await _get(resource_type, params)
+    return [e["resource"] for e in (bundle.get("entry") or []) if e.get("resource")]
+
+
+def _parse(model_cls, raw_list: list[dict], label: str) -> list:
+    out = []
+    for raw in raw_list:
+        try:
+            out.append(model_cls.model_validate(_normalize(raw)))
+        except Exception as exc:  # tolerate per-resource R5 deviations
+            logger.warning("skip unparseable %s: %s", label, str(exc)[:160])
+    return out
+
+
+def _parse_one(model_cls, raw: dict | None, label: str):
+    if not raw:
+        return None
+    try:
+        return model_cls.model_validate(_normalize(raw))
+    except Exception as exc:
+        logger.warning("skip unparseable %s: %s", label, str(exc)[:160])
+        return None
+
+
+# ─── searches ─────────────────────────────────────────────────────────────────
+async def search_encounters(params: dict) -> list[Encounter]:
+    return _parse(Encounter, await _search("Encounter", params), "Encounter")
+
+
+async def search_locations(params: dict) -> list[Location]:
+    return _parse(Location, await _search("Location", params), "Location")
+
+
+async def search_observations(params: dict) -> list[Observation]:
+    return _parse(Observation, await _search("Observation", params), "Observation")
+
+
+async def search_organizations(params: dict) -> list[Organization]:
+    return _parse(Organization, await _search("Organization", params), "Organization")
+
+
+async def search_patients(params: dict) -> list[Patient]:
+    return _parse(Patient, await _search("Patient", params), "Patient")
+
+
+async def search_patients_by_phone(normalized_phone: str) -> list[Patient]:
+    """Search Patient by phone number, trying ?phone= first then ?telecom= as fallback.
+
+    The FHIR adapter may support only one of the two params. `phone` (standard FHIR
+    ContactPoint system=phone search) is tried first; on 400/404/501 (param not
+    supported) or an empty result, we retry with the generic `telecom` alias.
+    """
+    for param in ("phone", "telecom"):
+        try:
+            results = _parse(Patient, await _search("Patient", {param: normalized_phone}), "Patient")
+            if results or param == "telecom":
+                return results
+            # phone returned empty — retry with telecom (adapter may store under different param)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (400, 404, 501) and param == "phone":
+                logger.info(
+                    "FHIR ?phone= returned %s, retrying with ?telecom=",
+                    exc.response.status_code,
+                )
+                continue
+            raise
+    return []
+
+
+async def search_tasks(params: dict) -> list[Task]:
+    return _parse(Task, await _search("Task", params), "Task")
+
+
+async def search_service_requests(params: dict) -> list[ServiceRequest]:
+    return _parse(ServiceRequest, await _search("ServiceRequest", params), "ServiceRequest")
+
+
+async def search_compositions(params: dict) -> list[Composition]:
+    return _parse(Composition, await _search("Composition", params), "Composition")
+
+
+async def search_specimens(params: dict) -> list[Specimen]:
+    return _parse(Specimen, await _search("Specimen", params), "Specimen")
+
+
+async def search_devices(params: dict) -> list[Device]:
+    return _parse(Device, await _search("Device", params), "Device")
+
+
+async def search_medication_requests(params: dict) -> list[MedicationRequest]:
+    return _parse(MedicationRequest, await _search("MedicationRequest", params), "MedicationRequest")
+
+
+async def search_inventory_items(params: dict) -> list:
+    if InventoryItem is None:
+        logger.warning("fhir.resources does not include InventoryItem on this install")
+        return []
+    return _parse(InventoryItem, await _search("InventoryItem", params), "InventoryItem")
+
+
+# ─── reads ────────────────────────────────────────────────────────────────────
+async def read_encounter(rid: str) -> Encounter | None:
+    return _parse_one(Encounter, await _get_or_none(f"Encounter/{rid}"), "Encounter")
+
+
+async def read_location(rid: str) -> Location | None:
+    return _parse_one(Location, await _get_or_none(f"Location/{rid}"), "Location")
+
+
+async def read_observation(rid: str) -> Observation | None:
+    return _parse_one(Observation, await _get_or_none(f"Observation/{rid}"), "Observation")
+
+
+async def read_patient(rid: str) -> Patient | None:
+    return _parse_one(Patient, await _get_or_none(f"Patient/{rid}"), "Patient")
+
+
+# ─── writes (normalized → FHIR is done in service.writes; this is transport) ────
+async def patch(resource_type: str, resource_id: str, ops: list[dict]) -> dict:
+    """FHIR JSON-Patch (RFC 6902) against {base}/{Type}/{id}.
+
+    `ops` example: [{"op": "add", "path": "/interpretation", "value": [...]}].
+    The DB's write contract is documented in docs/INTEGRATION.md §writes.
+    """
+    base = settings.ehr_fhir_base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.patch(
+            f"{base}/{resource_type}/{resource_id}",
+            json=ops,
+            headers=_headers({"Content-Type": "application/json-patch+json"}),
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}
+
+
+async def try_patch(resource_type: str, resource_id: str, ops: list[dict]) -> bool:
+    """PATCH that tolerates a 404 (resource id doesn't exist) by returning False.
+    Used for vitals, where one reading is several measure-prefixed Observations and
+    only some measures exist. Other HTTP errors still raise."""
+    base = settings.ehr_fhir_base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.patch(
+            f"{base}/{resource_type}/{resource_id}",
+            json=ops,
+            headers=_headers({"Content-Type": "application/json-patch+json"}),
+        )
+        if resp.status_code == 404:
+            return False
+        resp.raise_for_status()
+        return True
+
+
+async def put(resource_type: str, resource_id: str, resource: dict) -> dict:
+    """Full FHIR update — PUT {base}/{Type}/{id} with a complete resource."""
+    base = settings.ehr_fhir_base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.put(
+            f"{base}/{resource_type}/{resource_id}",
+            json=resource,
+            headers=_headers({"Content-Type": "application/fhir+json"}),
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}
+
+
+# ─── change feed (DB → Fabric incremental sync) ─────────────────────────────────
+_MODEL_BY_TYPE = {
+    "Encounter": Encounter, "Location": Location, "Observation": Observation,
+    "Organization": Organization, "Patient": Patient, "Task": Task,
+    "ServiceRequest": ServiceRequest, "Composition": Composition,
+    "Specimen": Specimen, "Device": Device, "MedicationRequest": MedicationRequest,
+    **({} if InventoryItem is None else {"InventoryItem": InventoryItem}),
+}
+
+
+def parse_resource(raw: dict):
+    """Parse a raw FHIR resource dict (from the change feed) into its model, or None
+    if the type is unknown or the payload is unparseable."""
+    cls = _MODEL_BY_TYPE.get(raw.get("resourceType")) if isinstance(raw, dict) else None
+    if cls is None:
+        return None
+    return _parse_one(cls, raw, raw.get("resourceType"))
+
+
+async def get_changed_resources() -> dict:
+    """GET the DB's incremental change feed (a FHIR `collection` Bundle of changed
+    resources since the last acknowledgment)."""
+    return await _get("Bundle/$changed-resources")
+
+
+async def ack_changed_resources() -> dict:
+    """Acknowledge the current change-feed snapshot so the DB clears it."""
+    base = settings.ehr_fhir_base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.post(
+            f"{base}/Bundle/$changed-resources/$acknowledge",
+            json={},
+            headers=_headers({"Content-Type": "application/fhir+json"}),
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}

--- a/fabric/src/clients/rest_client.py
+++ b/fabric/src/clients/rest_client.py
@@ -1,0 +1,87 @@
+"""Generic HTTP client for the DB's plain-REST APIs (financial, OT, ambulance, appointments).
+
+These upstreams share one contract: list endpoints return `{ "data": [...], "total": N }`
+and single reads return the object. All use the same bearer key as the financial API
+(`settings.financial_key`). Fabric passes the JSON straight through — it's already the
+dict shape the agents want, so no FHIR transform is involved.
+
+Callers pass the upstream `base_url` per call (see service/financial.py, service/ot.py, …).
+The initial-sync API uses a different (keyset-pagination) envelope and lives in
+sync_client.py, which reuses `auth_headers` from here.
+"""
+
+import logging
+
+import httpx
+
+from config import settings
+
+logger = logging.getLogger("rest_client")
+
+
+def auth_headers() -> dict:
+    """Bearer auth shared by all the DB's plain-REST APIs (incl. initial-sync)."""
+    h = {"Accept": "application/json"}
+    if settings.financial_key:
+        h["Authorization"] = f"Bearer {settings.financial_key}"
+    return h
+
+
+async def _get(base_url: str, path: str, params: dict | None = None):
+    url = f"{base_url.rstrip('/')}/{path}"
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.get(url, params=params, headers=auth_headers())
+        resp.raise_for_status()
+        return resp.json() if resp.content else None
+
+
+async def _post(base_url: str, path: str, body: dict | None = None):
+    url = f"{base_url.rstrip('/')}/{path}"
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.post(url, json=body, headers=auth_headers())
+        resp.raise_for_status()
+        return resp.json() if resp.content else None
+
+
+async def _patch(base_url: str, path: str, body: dict | None = None):
+    url = f"{base_url.rstrip('/')}/{path}"
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.patch(url, json=body, headers=auth_headers())
+        resp.raise_for_status()
+        return resp.json() if resp.content else None
+
+
+def _unwrap(payload) -> list[dict]:
+    """Unwrap {data:[...], total:N} or bare list."""
+    if isinstance(payload, dict):
+        return payload.get("data", [])
+    return payload or []
+
+
+async def list_(base_url: str, path: str, **params) -> list[dict]:
+    clean = {k: v for k, v in params.items() if v is not None}
+    return _unwrap(await _get(base_url, path, clean or None))
+
+
+async def safe_list(base_url: str, path: str, **params) -> list[dict]:
+    """Like list_ but degrades to [] if the upstream endpoint is unavailable."""
+    try:
+        return await list_(base_url, path, **params)
+    except Exception as exc:
+        logger.warning("REST %s/%s unavailable: %s", base_url, path, str(exc)[:120])
+        return []
+
+
+async def get_one(base_url: str, path: str):
+    """Single-object read (endpoints that return the object, not a {data,total} list)."""
+    return await _get(base_url, path)
+
+
+async def create(base_url: str, path: str, body: dict) -> dict:
+    result = await _post(base_url, path, body)
+    return result or {}
+
+
+async def update(base_url: str, path: str, body: dict | None = None) -> dict:
+    result = await _patch(base_url, path, body)
+    return result or {}

--- a/fabric/src/clients/sync_client.py
+++ b/fabric/src/clients/sync_client.py
@@ -1,0 +1,43 @@
+"""HTTP client for the DB's initial-sync API (GET /api/sync/<table>).
+
+Unlike the other plain-REST endpoints (financial/OT/ambulance), the sync API
+returns a full keyset-pagination envelope — sync_id, table, schema, pagination,
+rows — rather than {data:[...], total:N}. Fabric passes that envelope straight
+through to the main backend, so this client returns the raw JSON unchanged.
+
+Shares the same bearer key/auth as the plain-REST client (reuses its
+`auth_headers`, which reads settings.financial_key).
+"""
+
+import logging
+
+import httpx
+
+from clients.rest_client import auth_headers
+from config import settings
+
+logger = logging.getLogger("sync_client")
+
+
+async def fetch_page(
+    table: str,
+    *,
+    limit: int | None = None,
+    cursor: str | None = None,
+    sync_id: str | None = None,
+) -> dict:
+    """GET one keyset page from the DB's /api/sync/<table>.
+
+    Returns the full upstream envelope unchanged. Raises httpx.HTTPStatusError
+    on a non-2xx response so the caller can map the DB's status code through.
+    """
+    params = {
+        k: v
+        for k, v in {"limit": limit, "cursor": cursor, "sync_id": sync_id}.items()
+        if v is not None
+    }
+    url = f"{settings.sync_api_base_url.rstrip('/')}/{table}"
+    async with httpx.AsyncClient(timeout=settings.upstream_timeout) as client:
+        resp = await client.get(url, params=params or None, headers=auth_headers())
+        resp.raise_for_status()
+        return resp.json()

--- a/fabric/src/config.py
+++ b/fabric/src/config.py
@@ -1,0 +1,143 @@
+"""Hospilot-Fabric settings.
+
+Fabric is a TRANSFORMATION layer: it is a CLIENT of the DB's APIs. It calls the
+DB's FHIR API (clinical) + the DB's plain-REST financial API, transforms the
+responses into the normal dict shapes the main backend wants, and serves those.
+
+It needs:
+  • the DB's FHIR base URL + key   (clinical resources, FHIR R5)
+  • the DB's financial REST base URL + key   (invoices/claims/… plain JSON)
+  • its own API key                (guards Fabric's endpoints for the main app)
+  • its own public FHIR base URL   (mints identifier systems for write payloads)
+
+All values come from the environment / a local `.env` (see .env.example).
+"""
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings
+
+_INTEGRATION_MODES = {"change_api", "polling", "kafka"}
+
+
+class Settings(BaseSettings):
+    # ── upstream: the DB's FHIR API (what Fabric calls and transforms) ──────────
+    ehr_fhir_base_url: str = "http://localhost:3001/fhir"
+    ehr_fhir_api_key: str = ""
+
+    # ── upstream: the DB's plain-REST financial API ─────────────────────────────
+    financial_api_base_url: str = "http://localhost:3001/api/financial"
+    financial_api_key: str = ""        # empty => falls back to ehr_fhir_api_key
+
+    # ── downstream: Fabric's own auth (main app → Fabric) ───────────────────────
+    fabric_api_key: str = ""           # empty => Fabric auth disabled (dev)
+
+    # ── identity (used only when building FHIR write payloads) ──────────────────
+    fhir_base_url: str = "http://localhost:8002/fhir"
+    ehr_source: str = "hospilot"
+
+    # ── Kafka: Fabric publishes data-change events (read direction → main app) ──
+    # Empty bootstrap servers => publishing AND the change poller are disabled (dev).
+    kafka_bootstrap_servers: str = ""
+    kafka_topic_prefix: str = "hospilot.data"
+    kafka_client_id: str = "hospilot-fabric"
+    poll_interval_ms: int = 10000
+    # dedicated topic for write-proposal acknowledgements (DB accepted/rejected a change)
+    kafka_ack_topic: str = "hospilot.sync.ack"
+    # kafka-mode write leg: Fabric PUSHES approved changes here as single-entry FHIR
+    # Bundles; the DB consumes, applies, and acks on kafka_ack_topic. Only used when
+    # integration_mode=kafka (change_api/polling still use the HTTP $pending-changes pull).
+    kafka_write_topic: str = "hospilot.sync.write"
+    # drain cadence (ms) for the kafka-mode write publisher loop
+    write_drain_interval_ms: int = 1000
+    # soft-lock timeout: if the DB doesn't $confirm an in-flight snapshot within this
+    # window, the lock expires and its changes are re-offered on the next pull.
+    snapshot_lock_timeout_ms: int = 60000
+
+    # ── ingest mode: how Fabric learns about DB changes (read direction) ─────────
+    #   "change_api" (default) — poll the DB's FHIR $changed-resources change feed.
+    #   "polling"              — the DB has no change feed, so Fabric polls each
+    #                            per-resource API itself and publishes a field-level
+    #                            diff (only the changed columns). See diff_poller.py.
+    integration_mode: str = "change_api"
+    # polling-mode per-entity poll cadence (ms). Only used when integration_mode=polling.
+    # Defaults reflect clinical volatility: beds flip fast; labs/tasks are slower; the
+    # keyset-paginated lab_result table gets the slowest cadence.
+    poll_interval_bed_ms: int = 5000
+    poll_interval_admission_ms: int = 10000
+    poll_interval_visit_ms: int = 10000
+    poll_interval_lab_order_ms: int = 15000
+    poll_interval_task_ms: int = 15000
+    poll_interval_lab_result_ms: int = 30000
+    poll_interval_rest_ms: int = 10000        # ot_*, ambulance, appointment, doctor_slot
+
+    # ── app ─────────────────────────────────────────────────────────────────────
+    app_env: str = "development"
+    cors_origins: str = "*"
+    upstream_timeout: float = 20.0
+
+    @field_validator("integration_mode", mode="before")
+    @classmethod
+    def _normalize_integration_mode(cls, v: str) -> str:
+        mode = str(v).strip().lower()
+        if mode not in _INTEGRATION_MODES:
+            raise ValueError(
+                f"integration_mode must be one of {sorted(_INTEGRATION_MODES)}, got {v!r}"
+            )
+        return mode
+
+    @property
+    def kafka_enabled(self) -> bool:
+        return bool(self.kafka_bootstrap_servers)
+
+    @property
+    def polling_mode(self) -> bool:
+        return self.integration_mode == "polling"
+
+    @property
+    def kafka_mode(self) -> bool:
+        return self.integration_mode == "kafka"
+
+    @property
+    def poll_intervals_ms(self) -> dict[str, int]:
+        """Per-entity poll cadence (ms) for polling mode, keyed by topic entity."""
+        return {
+            "bed": self.poll_interval_bed_ms,
+            "admission": self.poll_interval_admission_ms,
+            "visit": self.poll_interval_visit_ms,
+            "lab_order": self.poll_interval_lab_order_ms,
+            "task": self.poll_interval_task_ms,
+            "lab_result": self.poll_interval_lab_result_ms,
+        }
+
+    @property
+    def snapshot_lock_timeout_s(self) -> float:
+        return self.snapshot_lock_timeout_ms / 1000
+
+    @property
+    def financial_key(self) -> str:
+        return self.financial_api_key or self.ehr_fhir_api_key
+
+    @property
+    def db_rest_base_url(self) -> str:
+        """Base URL for all DB plain-REST APIs (OT, ambulance, appointments).
+        Derived from financial_api_base_url by stripping /financial."""
+        url = self.financial_api_base_url.rstrip("/")
+        return url[: -len("/financial")] if url.endswith("/financial") else url
+
+    @property
+    def sync_api_base_url(self) -> str:
+        """Base URL for the DB's initial-sync API (GET /api/sync/<table>).
+        Derived from db_rest_base_url -> http://<host>/api/sync."""
+        return f"{self.db_rest_base_url}/sync"
+
+    @property
+    def cors_origin_list(self) -> list[str]:
+        return [o.strip() for o in self.cors_origins.split(",")]
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        extra = "ignore"
+
+
+settings = Settings()

--- a/fabric/src/fhirgw/__init__.py
+++ b/fabric/src/fhirgw/__init__.py
@@ -1,0 +1,20 @@
+"""
+fhirgw — Hospilot's in-app FHIR gateway (canonical FHIR R5 / 5.0.0).
+
+Named `fhirgw` (not `fhir`) on purpose: the app runs with `src/` on the import
+root (see server.sh), so a package literally named `fhir` would shadow the
+`fhir.resources` library and break `from fhir.resources... import ...`.
+
+Layout:
+  terminology.py   — code systems + LOINC/status/class/interpretation maps
+  identifiers.py   — internal id / patient_token -> FHIR identifier system+value
+  extensions.py    — Hospilot extension URLs + build/read helpers
+  serialization.py — fhir.resources model -> FastAPI/Starlette Response
+  outcomes.py      — OperationOutcome builders + FHIRError
+  bundle.py        — searchset Bundle assembly
+  security.py      — /fhir auth dependency
+  views.py         — to_internal projection re-exports (used by the poller)
+  mappers/         — bidirectional internal-dict <-> canonical FHIR
+"""
+
+FHIR_VERSION = "5.0.0"  # fhir.resources top-level == R5

--- a/fabric/src/fhirgw/bundle.py
+++ b/fabric/src/fhirgw/bundle.py
@@ -1,0 +1,278 @@
+"""Build a FHIR R5 transaction Bundle from the in-memory change queue.
+
+Each pending change becomes EXACTLY one Bundle entry — a FHIRPath Patch (Parameters
+resource) for PATCH operations, or a full FHIR resource for POST operations — carrying
+`fullUrl = urn:hospilot:change:<change_id>` so the DB can reference each change back in
+its $confirm response. Changes are NOT merged per resource: the per-change identity is
+what the two-phase confirm protocol keys on.
+
+Changes whose resource_id is unknown at queue time (critical_vital, ai_discharge_note)
+are resolved with a live DB lookup (resolve_changes) before the snapshot is committed.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from clients import fhir_client as fc
+from fhirgw import extensions as X, terminology as T
+from service.change_store import PendingChange
+
+logger = logging.getLogger("bundle")
+
+_CHANGE_URN = "urn:hospilot:change:"   # fullUrl prefix carrying the change_id
+
+_VITAL_MEASURES = ("hr-", "temp-", "spo2-", "rr-", "bp-", "gcs-")
+
+_EXT_ADM_TRANSFER_PENDING = X.EXT_BASE + "admission-transfer-pending"
+_EXT_DISCHARGE_AI_NOTE    = X.EXT_BASE + "discharge-ai-note"
+_EXT_RAW_APPOINTMENT      = X.EXT_BASE + "raw-appointment-data"
+_EXT_RAW_SURGERY_RESCHEDULE = X.EXT_BASE + "surgery-reschedule-data"
+
+
+# ─── FHIRPath Patch helpers ────────────────────────────────────────────────────
+
+def _fhirpath_op(op: dict) -> dict:
+    """Convert an op descriptor to a FHIR FHIRPath Patch operation parameter."""
+    parts: list[dict] = [{"name": "type", "valueCode": op["type"]}]
+    if op["type"] == "add":
+        parts.append({"name": "path", "valueString": op["parent"]})
+        parts.append({"name": "name", "valueString": op["name"]})
+        val_part: dict = {"name": "value"}
+        val_part[op["value_key"]] = op["value"]
+        parts.append(val_part)
+    elif op["type"] == "replace":
+        parts.append({"name": "path", "valueString": op["path"]})
+        val_part = {"name": "value"}
+        val_part[op["value_key"]] = op["value"]
+        parts.append(val_part)
+    elif op["type"] == "delete":
+        parts.append({"name": "path", "valueString": op["path"]})
+    return {"name": "operation", "part": parts}
+
+
+def _parameters(ops: list[dict]) -> dict:
+    return {
+        "resourceType": "Parameters",
+        "parameter": [_fhirpath_op(op) for op in ops],
+    }
+
+
+# ─── Op descriptors per change type ───────────────────────────────────────────
+
+def _ops_for(change: PendingChange) -> list[dict]:
+    p = change.payload
+    match change.change_type:
+        case "bed_status":
+            return [{
+                "type": "replace",
+                "path": "Location.operationalStatus",
+                "value_key": "valueCoding",
+                "value": {
+                    "system": T.SYS_LOCATION_OPER_STATUS,
+                    "code": p["code"],
+                    "display": p["display"],
+                },
+            }]
+        case "triage_score":
+            return [{
+                "type": "add", "parent": "Encounter", "name": "extension",
+                "value_key": "valueExtension",
+                "value": X.ext_int(X.EXT_VISIT_TRIAGE_SCORE, p["score"]),
+            }]
+        case "discharge_ready":
+            ops = [{
+                "type": "add", "parent": "Encounter", "name": "extension",
+                "value_key": "valueExtension",
+                "value": X.ext_bool(X.EXT_ADM_DISCHARGE_READY, p["ready"]),
+            }]
+            if p.get("blocked_reason") is not None:
+                ops.append({
+                    "type": "add", "parent": "Encounter", "name": "extension",
+                    "value_key": "valueExtension",
+                    "value": X.ext_string(X.EXT_ADM_DISCHARGE_BLOCKED_REASON, p["blocked_reason"]),
+                })
+            return ops
+        case "transfer_pending":
+            return [{
+                "type": "add", "parent": "Encounter", "name": "extension",
+                "value_key": "valueExtension",
+                "value": X.ext_bool(_EXT_ADM_TRANSFER_PENDING, True),
+            }]
+        case "critical_vital":
+            return [
+                {"type": "delete", "path": "Observation.interpretation"},
+                {
+                    "type": "add", "parent": "Observation", "name": "interpretation",
+                    "value_key": "valueCodeableConcept",
+                    "value": {"coding": [{
+                        "system": T.SYS_INTERPRETATION,
+                        "code": T.CRITICAL_INTERP[0],
+                        "display": T.CRITICAL_INTERP[1],
+                    }]},
+                },
+            ]
+        case "ai_discharge_note":
+            return [{
+                "type": "add", "parent": "Composition", "name": "extension",
+                "value_key": "valueExtension",
+                "value": X.ext_string(_EXT_DISCHARGE_AI_NOTE, p["note"]),
+            }]
+        case "slot_book":
+            return [{
+                "type": "replace",
+                "path": "Slot.status",
+                "value_key": "valueCode",
+                "value": "busy",
+            }]
+        case "surgery_reschedule":
+            # Self-describing update: the raw {table_name, operation, record_id, fields}
+            # rides in one extension; the PATCH url (ot_surgeries/{id}) names the target.
+            return [{
+                "type": "add", "parent": change.resource_type, "name": "extension",
+                "value_key": "valueExtension",
+                "value": X.ext_string(_EXT_RAW_SURGERY_RESCHEDULE, json.dumps(p)),
+            }]
+        case _:
+            return []
+
+
+# ─── Bundle entry builders ─────────────────────────────────────────────────────
+
+def _patch_entry(resource_type: str, resource_id: str, ops: list[dict]) -> dict:
+    return {
+        "request": {"method": "PATCH", "url": f"{resource_type}/{resource_id}"},
+        "resource": _parameters(ops),
+    }
+
+
+def _appointment_entry(body: dict) -> dict:
+    resource: dict = {"resourceType": "Appointment", "status": "proposed"}
+    participants: list[dict] = []
+    _seen_refs: set[str] = set()
+    for field, ref_prefix in (
+        ("patient_id", "Patient"),
+        ("patient",    "Patient"),
+        ("provider_id", "Practitioner"),
+        ("provider",    "Practitioner"),
+        ("department_id", "Organization"),
+        ("department",    "Organization"),
+    ):
+        if val := body.get(field):
+            ref = f"{ref_prefix}/{val}"
+            if ref not in _seen_refs:
+                _seen_refs.add(ref)
+                participants.append({"actor": {"reference": ref}, "status": "accepted"})
+    if participants:
+        resource["participant"] = participants
+    if start := body.get("start") or body.get("date") or body.get("scheduled_at"):
+        resource["start"] = start
+    if end := body.get("end"):
+        resource["end"] = end
+    resource["extension"] = [{"url": _EXT_RAW_APPOINTMENT, "valueString": json.dumps(body)}]
+    return {
+        "request": {"method": "POST", "url": "Appointment"},
+        "resource": resource,
+    }
+
+
+# ─── ID resolution ─────────────────────────────────────────────────────────────
+
+def _with_resource_id(change: PendingChange, resource_type: str, resource_id: str) -> PendingChange:
+    """Clone a change with its resolved resource_id, preserving identity fields
+    (change_id/entity/record_id) so the in-flight snapshot and the Bundle agree."""
+    return PendingChange(
+        change_type=change.change_type,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        http_method=change.http_method,
+        payload=change.payload,
+        timestamp=change.timestamp,
+        change_id=change.change_id,
+        entity=change.entity,
+        record_id=change.record_id,
+        approval_needed=change.approval_needed,
+    )
+
+
+async def resolve_changes(changes: list[PendingChange]) -> list[PendingChange]:
+    """Fill in resource_id for changes that couldn't know it at queue time.
+
+    Changes whose target can't be resolved (the Observation/Composition doesn't exist)
+    are DROPPED here (logged) — they never enter the in-flight snapshot, so every change
+    the DB receives carries a change_id it can confirm. Called by the GET handler BEFORE
+    committing the snapshot."""
+    resolved: list[PendingChange] = []
+    for change in changes:
+        if change.change_type == "critical_vital":
+            vital_id = change.payload["vital_id"]
+            hit = None
+            for measure in _VITAL_MEASURES:
+                rid = f"{measure}{vital_id}"
+                if await fc.read_observation(rid) is not None:
+                    hit = rid
+                    break
+            if hit:
+                resolved.append(_with_resource_id(change, "Observation", hit))
+            else:
+                logger.warning("drop critical_vital change %s: no Observation for vital %s",
+                               change.change_id, vital_id)
+        elif change.change_type == "ai_discharge_note":
+            admission_id = change.payload["admission_id"]
+            comps = await fc.search_compositions({
+                "subject": f"Encounter/{admission_id}",
+                # FHIR token search (system|code); CarerOS's own Composition builder
+                # (fhirCompositionBuilder.js) tags discharge summaries with this LOINC
+                # code. The CarerOS search route doesn't actually filter on `type` today
+                # (subject/patient/_count only) — sent anyway for correctness/future-proofing.
+                "type": "http://loinc.org|18842-5",
+            })
+            if comps:
+                resolved.append(_with_resource_id(change, "Composition", comps[0].id))
+            else:
+                logger.warning("drop ai_discharge_note change %s: no Composition for %s",
+                               change.change_id, admission_id)
+        else:
+            resolved.append(change)
+    return resolved
+
+
+# ─── Public API ────────────────────────────────────────────────────────────────
+
+def build_snapshot_bundle(
+    changes: list[PendingChange], snapshot_id: str, include_approval: bool = True
+) -> dict:
+    """Build a FHIR R5 transaction Bundle from an already-resolved change set.
+
+    One entry per change (no per-resource merging), each tagged with
+    `fullUrl = urn:hospilot:change:<change_id>` so the DB echoes change ids back in
+    $confirm. `Bundle.id` and `Bundle.identifier` carry the snapshot id. Resolution is
+    done by the caller (resolve_changes) before the snapshot is committed, so `changes`
+    here already have a concrete resource_id.
+
+    `include_approval` controls the non-standard `entry.approvalNeeded` key: the HTTP
+    pull path keeps it (True) for the DB's existing applier; the kafka write leg passes
+    False so the emitted Bundle is spec-clean and approval rides in the message envelope
+    instead (see ingest.kafka_write_publisher)."""
+    entries: list[dict] = []
+    for change in changes:
+        if change.http_method == "POST":
+            entry = _appointment_entry(change.payload["body"])
+        else:
+            ops = _ops_for(change)
+            if not ops:
+                continue
+            entry = _patch_entry(change.resource_type, change.resource_id, ops)
+        entry["fullUrl"] = _CHANGE_URN + change.change_id
+        if include_approval:
+            entry["approvalNeeded"] = change.approval_needed
+        entries.append(entry)
+
+    return {
+        "resourceType": "Bundle",
+        "id": snapshot_id,
+        "identifier": {"system": _CHANGE_URN + "snapshot", "value": snapshot_id},
+        "type": "transaction",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "entry": entries,
+    }

--- a/fabric/src/fhirgw/extensions.py
+++ b/fabric/src/fhirgw/extensions.py
@@ -1,0 +1,110 @@
+"""
+Hospilot FHIR extensions.
+
+Hospilot enrichment columns that have no native home on a base FHIR resource
+ride along as `extension[]`. We also round-trip a few *operational* values
+(e.g. the raw bed status string) via extensions so `to_internal(to_fhir(x))`
+reproduces the exact projection agents consume — see the round-trip tests.
+
+Helpers accept either fhir.resources model instances or plain dicts when
+reading, so they work whether you hold a parsed model or a model_dump().
+"""
+
+EXT_BASE = "https://hospilot.carer.ai/fhir/StructureDefinition/"
+
+# Bed (Location) enrichment + round-tripped operational fields
+EXT_BED_VENTILATION    = EXT_BASE + "bed-ventilation"
+EXT_BED_ROOM_SHARING   = EXT_BASE + "bed-room-sharing"
+EXT_BED_PROXIMITY      = EXT_BASE + "bed-proximity"
+EXT_BED_FLOOR          = EXT_BASE + "bed-floor"
+EXT_BED_WING           = EXT_BASE + "bed-wing"
+EXT_BED_NATURAL_LIGHT  = EXT_BASE + "bed-natural-light"
+EXT_BED_NOISE_LEVEL    = EXT_BASE + "bed-noise-level"
+EXT_BED_FEATURE        = EXT_BASE + "bed-feature"        # repeated, one per feature
+EXT_BED_RAW_STATUS     = EXT_BASE + "bed-raw-status"     # preserves "reserved"/"Dirty"/etc.
+EXT_BED_WARD           = EXT_BASE + "bed-ward"
+EXT_BED_ROOM_TYPE      = EXT_BASE + "bed-room-type"
+EXT_BED_BRANCH_ID      = EXT_BASE + "bed-branch-id"
+
+# Admission (Encounter IMP) — enrichment + lossless round-trip of projection fields
+EXT_ADM_DISCHARGE_READY          = EXT_BASE + "admission-discharge-ready"
+EXT_ADM_DISCHARGE_BLOCKED_REASON = EXT_BASE + "admission-discharge-blocked-reason"
+EXT_ADM_EXPECTED_DISCHARGE       = EXT_BASE + "admission-expected-discharge-at"  # raw string
+EXT_ADM_ADMITTED_AT              = EXT_BASE + "admission-admitted-at"            # raw string
+EXT_ADM_RAW_STATUS               = EXT_BASE + "admission-raw-status"            # internal status code
+
+# Visit (Encounter EMER) — enrichment + lossless round-trip of projection fields
+EXT_VISIT_TRIAGE_SCORE  = EXT_BASE + "visit-triage-score"
+EXT_VISIT_ARRIVED_AT    = EXT_BASE + "visit-arrived-at"    # raw string
+EXT_VISIT_RAW_STATUS    = EXT_BASE + "visit-raw-status"    # internal status code
+
+# Organization (department)
+EXT_ORG_RAW_TYPE = EXT_BASE + "organization-raw-type"
+
+# Vital (Observation) — enrichment + lossless round-trip
+EXT_VITAL_IS_CRITICAL  = EXT_BASE + "vital-is-critical"
+EXT_VITAL_ADMISSION_ID = EXT_BASE + "vital-admission-id"
+EXT_VITAL_RECORDED_AT  = EXT_BASE + "vital-recorded-at"   # raw string
+
+
+# ─── builders ─────────────────────────────────────────────────────────────────
+def ext_string(url: str, value) -> dict:
+    return {"url": url, "valueString": str(value)}
+
+
+def ext_int(url: str, value) -> dict:
+    return {"url": url, "valueInteger": int(value)}
+
+
+def ext_bool(url: str, value) -> dict:
+    return {"url": url, "valueBoolean": bool(value)}
+
+
+def ext_decimal(url: str, value) -> dict:
+    return {"url": url, "valueDecimal": value}
+
+
+_VALUE_FIELDS = (
+    "valueString", "valueInteger", "valueBoolean", "valueDecimal",
+    "valueDateTime", "valueCode",
+)
+
+
+def _url_of(e) -> str | None:
+    return e.get("url") if isinstance(e, dict) else getattr(e, "url", None)
+
+
+def _value_of(e):
+    if isinstance(e, dict):
+        for f in _VALUE_FIELDS:
+            if e.get(f) is not None:
+                return e[f]
+        return None
+    for f in _VALUE_FIELDS:
+        v = getattr(e, f, None)
+        if v is not None:
+            return v
+    return None
+
+
+def get_ext(extensions, url: str):
+    """First extension value matching `url`, or None. Works on models or dicts."""
+    if not extensions:
+        return None
+    for e in extensions:
+        if _url_of(e) == url:
+            return _value_of(e)
+    return None
+
+
+def get_ext_all(extensions, url: str) -> list:
+    """All values for a repeated extension (e.g. bed features)."""
+    out: list = []
+    if not extensions:
+        return out
+    for e in extensions:
+        if _url_of(e) == url:
+            v = _value_of(e)
+            if v is not None:
+                out.append(v)
+    return out

--- a/fabric/src/fhirgw/identifiers.py
+++ b/fabric/src/fhirgw/identifiers.py
@@ -1,0 +1,58 @@
+"""
+Identifier strategy.
+
+- Logical `.id` on each resource is the internal UUID (URL-safe, stable) so
+  `GET /fhir/Location/{uuid}` is a direct cache lookup.
+- `.identifier` mirrors it with a Hospilot `system` URI so external systems have
+  a namespaced business identifier.
+- Patient is PSEUDONYMOUS: its ONLY identifier is the `patient_token`; no name,
+  birthDate, gender, or other PHI is ever attached (PHI lives in CarerOS).
+
+Identifier systems are derived from settings.fhir_base_url so they are stable
+per-deployment. Distinct systems for admission-vs-visit and vital-vs-lab let a
+future write-back route a resource to the correct Hospilot table.
+"""
+
+from config import settings
+
+
+def _base() -> str:
+    return settings.fhir_base_url.rstrip("/")
+
+
+def sys_patient_token() -> str: return f"{_base()}/identifier/patient-token"
+def sys_admission() -> str:     return f"{_base()}/identifier/admission"
+def sys_visit() -> str:         return f"{_base()}/identifier/visit"
+def sys_bed() -> str:           return f"{_base()}/identifier/bed"
+def sys_department() -> str:    return f"{_base()}/identifier/department"
+def sys_organization() -> str:  return f"{_base()}/identifier/organization"
+def sys_vital() -> str:         return f"{_base()}/identifier/vital"
+def sys_lab() -> str:           return f"{_base()}/identifier/lab-result"
+def sys_lab_code() -> str:      return f"{_base()}/CodeSystem/lab-test-code"
+
+
+# ─── source facility (Observation.performer when no individual is recorded) ────
+def source_organization_id() -> str:
+    """Stable id of the recording system/facility, derived from the EHR source."""
+    return f"source-{settings.ehr_source}"
+
+
+def source_organization_reference() -> dict:
+    return reference("Organization", source_organization_id())
+
+
+def identifier(system: str, value) -> dict:
+    return {"system": system, "value": str(value)}
+
+
+def patient_identifier(token) -> dict:
+    return identifier(sys_patient_token(), token)
+
+
+def reference(resource_type: str, rid) -> dict:
+    """A FHIR relative reference, e.g. {'reference': 'Patient/<token>'}."""
+    return {"reference": f"{resource_type}/{rid}"}
+
+
+def patient_reference(token) -> dict:
+    return reference("Patient", token)

--- a/fabric/src/fhirgw/mappers/__init__.py
+++ b/fabric/src/fhirgw/mappers/__init__.py
@@ -1,0 +1,1 @@
+"""Bidirectional mappers: internal Hospilot dicts <-> canonical FHIR R5."""

--- a/fabric/src/fhirgw/mappers/_common.py
+++ b/fabric/src/fhirgw/mappers/_common.py
@@ -1,0 +1,116 @@
+"""Shared read helpers that work on either fhir.resources model instances or dicts."""
+
+from decimal import Decimal
+
+
+def _coerce_decimal(v):
+    """fhir.resources stores Quantity.value as decimal.Decimal. Convert to a plain
+    Python numeric so JSON serialization (httpx / json.dumps) doesn't fail."""
+    if not isinstance(v, Decimal):
+        return v
+    f = float(v)
+    return int(f) if f == int(f) else f
+
+
+def parse_dt_safe(value):
+    """Return value only if it's a FHIR-acceptable dateTime (tz-aware when timed).
+
+    FHIR rejects naive timestamps like '2025-01-15T10:30:00' and normalizes the
+    rest, so we set proper FHIR dateTime fields only when safe and always keep
+    the raw string in an extension for lossless to_internal recovery.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    if "T" in value:
+        tail = value.split("T", 1)[1]
+        if not (value.endswith("Z") or "+" in tail or "-" in tail):
+            return None  # naive -> would raise; rely on the extension instead
+    return value
+
+
+def ref_id(reference_obj):
+    """'Patient/123' -> '123' from a Reference (model or dict). None if absent."""
+    if reference_obj is None:
+        return None
+    ref = reference_obj.get("reference") if isinstance(reference_obj, dict) else getattr(reference_obj, "reference", None)
+    if not ref or "/" not in ref:
+        return None
+    return ref.split("/", 1)[1]
+
+
+# CarerOS prefixes its FHIR resource ids by type (e.g. `em-<uuid>`, `ipd-<uuid>`,
+# `bed-<uuid>`, `spo2-<uuid>`). Hospilot-owned writes key on the bare DB uuid, so
+# strip a known prefix before writing back. (Bare Hospilot uuids have no such
+# prefix and pass through unchanged.)
+_FHIR_ID_PREFIXES = ("ipd-", "em-", "bed-", "ward-", "spo2-", "hr-", "rr-",
+                     "temp-", "bp-", "gcs-", "vitals-", "lab-", "task-", "comp-")
+
+
+def bare_id(fhir_id: str | None) -> str | None:
+    """Recover the bare DB key from a (possibly CarerOS-prefixed) FHIR id."""
+    if not fhir_id:
+        return fhir_id
+    for p in _FHIR_ID_PREFIXES:
+        if fhir_id.startswith(p):
+            return fhir_id[len(p):]
+    return fhir_id
+
+
+def location_ref_id(location_list):
+    if not location_list:
+        return None
+    first = location_list[0]
+    loc = first.get("location") if isinstance(first, dict) else getattr(first, "location", None)
+    return ref_id(loc)
+
+
+def _get(obj, key):
+    return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+
+def reason_text(reason_list):
+    """Chief-complaint text from R5 Encounter.reason[].value[].concept.text.
+
+    R5 changed reasonCode (CodeableConcept[]) to reason[] whose `value` is a
+    CodeableReference (concept | reference). We carry free text in concept.text.
+    """
+    if not reason_list:
+        return None
+    value = _get(reason_list[0], "value")
+    if not value:
+        return None
+    concept = _get(value[0], "concept")
+    if concept is None:
+        return None
+    return _get(concept, "text")
+
+
+def coding_code(codeable_concept):
+    """First coding.code from a CodeableConcept (model or dict)."""
+    if codeable_concept is None:
+        return None
+    coding = codeable_concept.get("coding") if isinstance(codeable_concept, dict) else getattr(codeable_concept, "coding", None)
+    if not coding:
+        return None
+    first = coding[0]
+    return first.get("code") if isinstance(first, dict) else getattr(first, "code", None)
+
+
+def qty_value(value_quantity):
+    if value_quantity is None:
+        return None
+    v = value_quantity.get("value") if isinstance(value_quantity, dict) else getattr(value_quantity, "value", None)
+    return _coerce_decimal(v)
+
+
+def num(value):
+    """Coerce a possibly-stringified or Decimal numeric to a plain Python number."""
+    if isinstance(value, Decimal):
+        return _coerce_decimal(value)
+    if isinstance(value, str):
+        try:
+            f = float(value)
+            return int(f) if f == int(f) else f
+        except ValueError:
+            return None
+    return value

--- a/fabric/src/fhirgw/mappers/encounter.py
+++ b/fabric/src/fhirgw/mappers/encounter.py
@@ -1,0 +1,123 @@
+"""admission/visit <-> FHIR Encounter.
+
+IPD admissions  -> Encounter.class = IMP
+ER visits       -> Encounter.class = EMER
+
+Timestamps and the raw internal status are preserved in extensions (FHIR
+dateTime normalizes/rejects some values and the status mapping isn't 1:1), so
+to_internal reproduces the exact projection agents consume.
+
+NOT LIVE in fabric/: no caller in src/ constructs an Encounter via
+admission_to_fhir/visit_to_fhir (bundle.py writes FHIRPath Patch ops directly,
+without building resources). transform.py uses only to_internal() from this
+module, on the inbound path.
+"""
+
+from fhir.resources.encounter import Encounter
+
+from fhirgw import terminology as T, extensions as X, identifiers as ID, narrative as N
+from fhirgw.mappers._common import parse_dt_safe, ref_id, location_ref_id, reason_text
+
+ADMISSION_KEYS = ("id", "patient_token", "bed_id", "admitted_at", "expected_discharge_at", "status")
+VISIT_KEYS = ("id", "patient_token", "department_id", "arrived_at", "status", "chief_complaint")
+
+
+# ─── Admission (IMP) ──────────────────────────────────────────────────────────
+def admission_to_fhir(adm: dict) -> Encounter:
+    exts: list[dict] = []
+    if adm.get("admitted_at") is not None:
+        exts.append(X.ext_string(X.EXT_ADM_ADMITTED_AT, adm["admitted_at"]))
+    if adm.get("expected_discharge_at") is not None:
+        exts.append(X.ext_string(X.EXT_ADM_EXPECTED_DISCHARGE, adm["expected_discharge_at"]))
+    if adm.get("status") is not None:
+        exts.append(X.ext_string(X.EXT_ADM_RAW_STATUS, adm["status"]))
+
+    fhir_status = T.encounter_status_to_fhir(adm.get("status"))
+    kwargs: dict = {
+        "id": str(adm["id"]),
+        "identifier": [ID.identifier(ID.sys_admission(), adm["id"])],
+        "status": fhir_status,
+        "class": [{"coding": [T.ENCOUNTER_CLASS_IMP]}],
+        "text": N.text(f"Inpatient admission {adm['id']} — {fhir_status}"),
+    }
+    if adm.get("patient_token"):
+        kwargs["subject"] = ID.patient_reference(adm["patient_token"])
+    if adm.get("bed_id"):
+        kwargs["location"] = [{"location": ID.reference("Location", adm["bed_id"])}]
+    start = parse_dt_safe(adm.get("admitted_at"))
+    if start:
+        kwargs["actualPeriod"] = {"start": start}
+    if exts:
+        kwargs["extension"] = exts
+    return Encounter(**kwargs)
+
+
+def admission_to_internal(enc: Encounter) -> dict:
+    return {
+        "id": enc.id,
+        "patient_token": ref_id(enc.subject) or "",
+        "bed_id": location_ref_id(enc.location),
+        "admitted_at": X.get_ext(enc.extension, X.EXT_ADM_ADMITTED_AT),
+        "expected_discharge_at": X.get_ext(enc.extension, X.EXT_ADM_EXPECTED_DISCHARGE),
+        "status": X.get_ext(enc.extension, X.EXT_ADM_RAW_STATUS),
+    }
+
+
+# ─── ER visit (EMER) ──────────────────────────────────────────────────────────
+def visit_to_fhir(visit: dict) -> Encounter:
+    exts: list[dict] = []
+    if visit.get("arrived_at") is not None:
+        exts.append(X.ext_string(X.EXT_VISIT_ARRIVED_AT, visit["arrived_at"]))
+    if visit.get("status") is not None:
+        exts.append(X.ext_string(X.EXT_VISIT_RAW_STATUS, visit["status"]))
+    if visit.get("triage_score") is not None:
+        exts.append(X.ext_int(X.EXT_VISIT_TRIAGE_SCORE, visit["triage_score"]))
+
+    fhir_status = T.encounter_status_to_fhir(visit.get("status"))
+    kwargs: dict = {
+        "id": str(visit["id"]),
+        "identifier": [ID.identifier(ID.sys_visit(), visit["id"])],
+        "status": fhir_status,
+        "class": [{"coding": [T.ENCOUNTER_CLASS_EMER]}],
+        "text": N.text(f"Emergency visit {visit['id']} — {fhir_status}"),
+    }
+    if visit.get("patient_token"):
+        kwargs["subject"] = ID.patient_reference(visit["patient_token"])
+    if visit.get("department_id"):
+        kwargs["serviceProvider"] = ID.reference("Organization", visit["department_id"])
+    if visit.get("chief_complaint"):
+        # R5: Encounter.reason[].value is a CodeableReference (concept | reference).
+        kwargs["reason"] = [{"value": [{"concept": {"text": str(visit["chief_complaint"])}}]}]
+    start = parse_dt_safe(visit.get("arrived_at"))
+    if start:
+        kwargs["actualPeriod"] = {"start": start}
+    ts = visit.get("triage_score")
+    if ts in T.TRIAGE_PRIORITY:
+        code, disp = T.TRIAGE_PRIORITY[ts]
+        kwargs["priority"] = {"coding": [{"system": T.SYS_ACT_PRIORITY, "code": code, "display": disp}]}
+    if exts:
+        kwargs["extension"] = exts
+    return Encounter(**kwargs)
+
+
+def visit_to_internal(enc: Encounter) -> dict:
+    return {
+        "id": enc.id,
+        "patient_token": ref_id(enc.subject) or "",
+        "department_id": ref_id(enc.serviceProvider),
+        "arrived_at": X.get_ext(enc.extension, X.EXT_VISIT_ARRIVED_AT),
+        "status": X.get_ext(enc.extension, X.EXT_VISIT_RAW_STATUS),
+        "chief_complaint": reason_text(enc.reason),
+    }
+
+
+# ─── dispatcher (by identifier system; robust to the `class` keyword field) ───
+def to_internal(enc: Encounter) -> dict:
+    systems = []
+    for i in (enc.identifier or []):
+        s = i.get("system") if isinstance(i, dict) else getattr(i, "system", None)
+        if s:
+            systems.append(s)
+    if ID.sys_visit() in systems:
+        return visit_to_internal(enc)
+    return admission_to_internal(enc)

--- a/fabric/src/fhirgw/mappers/location.py
+++ b/fabric/src/fhirgw/mappers/location.py
@@ -1,0 +1,96 @@
+"""bed <-> FHIR Location.
+
+Hospilot enrichment columns ride as extensions. The raw operational status
+string (Available / reserved / Dirty / ...) is preserved in an extension so
+to_internal reproduces the exact value agents compare against.
+
+NOT LIVE in fabric/: no caller in src/ constructs a Location via to_fhir()
+(bundle.py writes FHIRPath Patch ops directly, without building resources).
+transform.py uses only to_internal() from this module, on the inbound path.
+"""
+
+from fhir.resources.location import Location
+
+from fhirgw import terminology as T, extensions as X, identifiers as ID, narrative as N
+
+# Operational columns accepted by the hospilot_beds upsert (no enrichment).
+OPERATIONAL_KEYS = ("id", "branch_id", "ward", "bed_number", "room_type", "status", "is_active")
+
+_STR_ENRICHMENT = {
+    "ventilation": X.EXT_BED_VENTILATION,
+    "room_sharing": X.EXT_BED_ROOM_SHARING,
+    "wing": X.EXT_BED_WING,
+    "noise_level": X.EXT_BED_NOISE_LEVEL,
+}
+
+
+def to_fhir(bed: dict) -> Location:
+    status = bed.get("status")
+    is_active = bed.get("is_active", True)
+
+    exts: list[dict] = []
+    if bed.get("ward") is not None:
+        exts.append(X.ext_string(X.EXT_BED_WARD, bed["ward"]))
+    if bed.get("room_type") is not None:
+        exts.append(X.ext_string(X.EXT_BED_ROOM_TYPE, bed["room_type"]))
+    if bed.get("branch_id") is not None:
+        exts.append(X.ext_string(X.EXT_BED_BRANCH_ID, bed["branch_id"]))
+    if status is not None:
+        exts.append(X.ext_string(X.EXT_BED_RAW_STATUS, status))
+    for key, url in _STR_ENRICHMENT.items():
+        if bed.get(key) is not None:
+            exts.append(X.ext_string(url, bed[key]))
+    if bed.get("proximity") is not None:
+        exts.append(X.ext_int(X.EXT_BED_PROXIMITY, bed["proximity"]))
+    if bed.get("floor") is not None:
+        exts.append(X.ext_int(X.EXT_BED_FLOOR, bed["floor"]))
+    if bed.get("natural_light") is not None:
+        exts.append(X.ext_bool(X.EXT_BED_NATURAL_LIGHT, bed["natural_light"]))
+    for feat in (bed.get("features") or []):
+        exts.append(X.ext_string(X.EXT_BED_FEATURE, feat))
+
+    _ward = bed.get("ward")
+    _summary = f"Bed {bed.get('bed_number') or bed['id']}" + (f" — {_ward}" if _ward else "") + (f" ({status})" if status else "")
+    kwargs: dict = {
+        "id": str(bed["id"]),
+        "identifier": [ID.identifier(ID.sys_bed(), bed["id"])],
+        "status": T.location_status(is_active, status),
+        "mode": "instance",
+        "form": {"coding": [{"system": T.SYS_LOCATION_PHYSICAL, "code": "bd", "display": "Bed"}]},
+        "text": N.text(_summary),
+    }
+    if bed.get("bed_number") is not None:
+        kwargs["name"] = str(bed["bed_number"])
+    op = T.operational_status(status)
+    if op:
+        kwargs["operationalStatus"] = {"system": T.SYS_LOCATION_OPER_STATUS, "code": op[0], "display": op[1]}
+    if exts:
+        kwargs["extension"] = exts
+    return Location(**kwargs)
+
+
+def to_internal(loc: Location) -> dict:
+    ext = loc.extension
+    return {
+        "id": loc.id,
+        "ward": X.get_ext(ext, X.EXT_BED_WARD),
+        "bed_number": loc.name,
+        "room_type": X.get_ext(ext, X.EXT_BED_ROOM_TYPE),
+        "status": X.get_ext(ext, X.EXT_BED_RAW_STATUS),
+        "is_active": loc.status != "inactive",
+        "branch_id": X.get_ext(ext, X.EXT_BED_BRANCH_ID),
+        "ventilation": X.get_ext(ext, X.EXT_BED_VENTILATION),
+        "room_sharing": X.get_ext(ext, X.EXT_BED_ROOM_SHARING),
+        "proximity": X.get_ext(ext, X.EXT_BED_PROXIMITY),
+        "floor": X.get_ext(ext, X.EXT_BED_FLOOR),
+        "wing": X.get_ext(ext, X.EXT_BED_WING),
+        "natural_light": X.get_ext(ext, X.EXT_BED_NATURAL_LIGHT),
+        "noise_level": X.get_ext(ext, X.EXT_BED_NOISE_LEVEL),
+        "features": X.get_ext_all(ext, X.EXT_BED_FEATURE),
+    }
+
+
+def to_upsert_row(loc: Location) -> dict:
+    """Operational columns only — what hospilot_beds upsert should write."""
+    full = to_internal(loc)
+    return {k: full.get(k) for k in OPERATIONAL_KEYS}

--- a/fabric/src/fhirgw/mappers/observation.py
+++ b/fabric/src/fhirgw/mappers/observation.py
@@ -1,0 +1,221 @@
+"""vitals/labs <-> FHIR Observation.
+
+A single vitals row becomes a SET of Observations (one per LOINC vital, plus a
+blood-pressure panel with two components). Each carries a deterministic composite
+id `{vital_id}.{loinc}` (uuid and loinc both contain '-', so we join with '.',
+which neither contains and FHIR ids permit).
+
+Lab results map one-to-one to a laboratory Observation (pilot: read-only / outbound).
+
+NOT LIVE in fabric/: no caller in src/ constructs an Observation via
+vitals_to_fhir/lab_result_to_observation (bundle.py writes FHIRPath Patch ops
+directly, without building resources). transform.py uses only
+vitals_to_internal() from this module, on the inbound path.
+"""
+
+from fhir.resources.observation import Observation
+
+from fhirgw import terminology as T, extensions as X, identifiers as ID, narrative as N
+from fhirgw.mappers._common import parse_dt_safe, ref_id, coding_code, qty_value, num
+
+
+def _quantity(value, unit: str) -> dict:
+    v = num(value) if isinstance(value, str) else value
+    return {"value": v, "unit": unit, "system": T.SYS_UCUM, "code": unit}
+
+
+def _loinc_code(code: str, display: str) -> dict:
+    """code CodeableConcept, appending any profile-required "magic" coding."""
+    coding = [{"system": T.SYS_LOINC, "code": code, "display": display}]
+    extra = T.VITAL_REQUIRED_CODINGS.get(code)
+    if extra:
+        coding.append({"system": T.SYS_LOINC, "code": extra[0], "display": extra[1]})
+    return {"coding": coding}
+
+
+def _shared(vital: dict) -> dict:
+    exts: list[dict] = []
+    if vital.get("recorded_at") is not None:
+        exts.append(X.ext_string(X.EXT_VITAL_RECORDED_AT, vital["recorded_at"]))
+    if vital.get("admission_id") is not None:
+        exts.append(X.ext_string(X.EXT_VITAL_ADMISSION_ID, vital["admission_id"]))
+    if vital.get("is_critical") is not None:
+        exts.append(X.ext_bool(X.EXT_VITAL_IS_CRITICAL, vital["is_critical"]))
+
+    shared: dict = {"performer": [ID.source_organization_reference()]}
+    if vital.get("patient_token"):
+        shared["subject"] = ID.patient_reference(vital["patient_token"])
+    if exts:
+        shared["extension"] = exts
+    eff = parse_dt_safe(vital.get("recorded_at"))
+    if eff:
+        shared["effectiveDateTime"] = eff
+    if vital.get("is_critical"):
+        shared["interpretation"] = [{"coding": [{
+            "system": T.SYS_INTERPRETATION,
+            "code": T.CRITICAL_INTERP[0], "display": T.CRITICAL_INTERP[1],
+        }]}]
+    return shared
+
+
+def _vital_summary(display: str, value_quantity, value_integer, component) -> str:
+    if value_quantity is not None:
+        return f"{display}: {value_quantity['value']} {value_quantity.get('unit', '')}".strip()
+    if value_integer is not None:
+        return f"{display}: {value_integer}"
+    if component:
+        parts = [f"{c['code']['coding'][0]['display']} {c['valueQuantity']['value']} "
+                 f"{c['valueQuantity'].get('unit', '')}".strip() for c in component]
+        return f"{display}: " + ", ".join(parts)
+    return display
+
+
+def _vital_obs(vid: str, code: str, display: str, shared: dict, *, value_quantity=None, value_integer=None, component=None) -> Observation:
+    cid = f"{vid}.{code}"
+    kwargs: dict = {
+        "id": cid,
+        "identifier": [ID.identifier(ID.sys_vital(), cid)],
+        "status": "final",
+        "code": _loinc_code(code, display),
+        "category": [{"coding": [{"system": T.SYS_OBS_CATEGORY, "code": T.OBS_CAT_VITAL_SIGNS}]}],
+        "text": N.text(_vital_summary(display, value_quantity, value_integer, component)),
+        **shared,
+    }
+    if value_quantity is not None:
+        kwargs["valueQuantity"] = value_quantity
+    if value_integer is not None:
+        kwargs["valueInteger"] = value_integer
+    if component is not None:
+        kwargs["component"] = component
+    return Observation(**kwargs)
+
+
+def vitals_to_fhir(vital: dict) -> list[Observation]:
+    vid = str(vital["id"])
+    shared = _shared(vital)
+    out: list[Observation] = []
+
+    for field, (code, display, unit) in T.VITALS_LOINC.items():
+        val = vital.get(field)
+        if val is None:
+            continue
+        if code == T.GCS_CODE:  # unit-less integer score -> valueInteger
+            out.append(_vital_obs(vid, code, display, shared, value_integer=int(num(val))))
+        else:
+            out.append(_vital_obs(vid, code, display, shared, value_quantity=_quantity(val, unit)))
+
+    sysv, diav = vital.get("bp_systolic"), vital.get("bp_diastolic")
+    if sysv is not None or diav is not None:
+        comps = []
+        if sysv is not None:
+            comps.append({"code": {"coding": [{"system": T.SYS_LOINC, "code": T.BP_SYSTOLIC[0], "display": T.BP_SYSTOLIC[1]}]},
+                          "valueQuantity": _quantity(sysv, T.BP_SYSTOLIC[2])})
+        if diav is not None:
+            comps.append({"code": {"coding": [{"system": T.SYS_LOINC, "code": T.BP_DIASTOLIC[0], "display": T.BP_DIASTOLIC[1]}]},
+                          "valueQuantity": _quantity(diav, T.BP_DIASTOLIC[2])})
+        out.append(_vital_obs(vid, T.BP_PANEL_CODE[0], T.BP_PANEL_CODE[1], shared, component=comps))
+
+    return out
+
+
+# Operational columns the hospilot_vitals upsert may write (excludes the
+# Hospilot-owned `is_critical` enrichment, matching the poller's old _map_vital).
+VITAL_UPSERT_COLUMNS = (
+    "id", "patient_token", "admission_id", "recorded_at",
+    "temperature", "pulse", "bp_systolic", "bp_diastolic",
+    "spo2", "respiratory_rate", "gcs",
+)
+
+
+def to_vital_upsert_rows(observations) -> list[dict]:
+    """Group a flat list of vital Observations back into operational upsert rows."""
+    groups: dict[str, list] = {}
+    for o in observations:
+        vid = (o.id or "").split(".")[0]
+        groups.setdefault(vid, []).append(o)
+    rows = []
+    for group in groups.values():
+        full = vitals_to_internal(group)
+        rows.append({k: full.get(k) for k in VITAL_UPSERT_COLUMNS})
+    return rows
+
+
+def vitals_to_internal(observations) -> dict:
+    obs_list = list(observations)
+    if not obs_list:
+        return {}
+    first = obs_list[0]
+    vid = (first.id or "").split(".")[0]
+    result = {
+        "id": vid,
+        "patient_token": ref_id(first.subject) or "",
+        "admission_id": X.get_ext(first.extension, X.EXT_VITAL_ADMISSION_ID),
+        "recorded_at": X.get_ext(first.extension, X.EXT_VITAL_RECORDED_AT),
+        "temperature": None, "pulse": None, "bp_systolic": None, "bp_diastolic": None,
+        "spo2": None, "respiratory_rate": None, "gcs": None,
+        "is_critical": X.get_ext(first.extension, X.EXT_VITAL_IS_CRITICAL),
+    }
+    loinc_to_field = {code: field for field, (code, _d, _u) in T.VITALS_LOINC.items()}
+    for obs in obs_list:
+        code = coding_code(obs.code)
+        if code in loinc_to_field:
+            field = loinc_to_field[code]
+            if field == "gcs":  # emitted as valueInteger, not a Quantity
+                result[field] = num(getattr(obs, "valueInteger", None) if not isinstance(obs, dict) else obs.get("valueInteger"))
+            else:
+                result[field] = qty_value(obs.valueQuantity)
+        elif code == T.BP_PANEL_CODE[0]:
+            for comp in (obs.component or []):
+                ccode = coding_code(comp.code if not isinstance(comp, dict) else comp.get("code"))
+                cvq = comp.valueQuantity if not isinstance(comp, dict) else comp.get("valueQuantity")
+                if ccode == T.BP_SYSTOLIC[0]:
+                    result["bp_systolic"] = qty_value(cvq)
+                elif ccode == T.BP_DIASTOLIC[0]:
+                    result["bp_diastolic"] = qty_value(cvq)
+    return result
+
+
+# ─── labs (one row -> one laboratory Observation) ─────────────────────────────
+def lab_result_to_observation(row: dict) -> Observation:
+    code = row.get("test_code")
+    name = row.get("test_name")
+    _val = row.get("result_value")
+    _unit = row.get("unit")
+    _label = name or (str(code) if code else "Lab result")
+    _summary = f"{_label}: {_val}" + (f" {_unit}" if _val is not None and _unit else "") if _val is not None else _label
+    kwargs: dict = {
+        "id": str(row["id"]),
+        "identifier": [ID.identifier(ID.sys_lab(), row["id"])],
+        "status": "final",
+        "category": [{"coding": [{"system": T.SYS_OBS_CATEGORY, "code": T.OBS_CAT_LABORATORY}]}],
+        "performer": [ID.source_organization_reference()],
+        "text": N.text(_summary),
+        "code": {
+            "coding": ([{"system": ID.sys_lab_code(), "code": str(code), "display": name}] if code else None),
+            "text": name,
+        },
+    }
+    if not code:
+        kwargs["code"] = {"text": name or "Unknown lab test"}
+    if row.get("patient_token"):
+        kwargs["subject"] = ID.patient_reference(row["patient_token"])
+    eff = parse_dt_safe(row.get("reported_at"))
+    if eff:
+        kwargs["effectiveDateTime"] = eff
+
+    val = row.get("result_value")
+    unit = row.get("unit")
+    fval = num(val) if isinstance(val, str) else val
+    if isinstance(fval, (int, float)) and unit:
+        kwargs["valueQuantity"] = {"value": fval, "unit": unit, "system": T.SYS_UCUM, "code": unit}
+    elif val is not None:
+        kwargs["valueString"] = str(val)
+
+    flag = row.get("flag")
+    if flag in T.INTERPRETATION_MAP:
+        c, d = T.INTERPRETATION_MAP[flag]
+        kwargs["interpretation"] = [{"coding": [{"system": T.SYS_INTERPRETATION, "code": c, "display": d}]}]
+    rr = row.get("reference_range")
+    if rr:
+        kwargs["referenceRange"] = [{"text": str(rr)}]
+    return Observation(**kwargs)

--- a/fabric/src/fhirgw/mappers/organization.py
+++ b/fabric/src/fhirgw/mappers/organization.py
@@ -1,0 +1,55 @@
+"""department <-> FHIR Organization.
+
+NOT LIVE in fabric/: no caller in src/ constructs an Organization via to_fhir()
+or source_organization() (bundle.py writes FHIRPath Patch ops directly, without
+building resources). transform.py uses only to_internal() from this module, on
+the inbound path.
+"""
+
+from fhir.resources.organization import Organization
+
+from fhirgw import extensions as X, identifiers as ID, narrative as N
+
+OPERATIONAL_KEYS = ("id", "name", "type")
+
+
+def to_fhir(dept: dict) -> Organization:
+    raw_type = dept.get("type")
+    name = dept.get("name")
+
+    kwargs: dict = {
+        "id": str(dept["id"]),
+        "identifier": [ID.identifier(ID.sys_department(), dept["id"])],
+        "text": N.text(str(name) if name else f"Organization {dept['id']}"),
+    }
+    if name:  # FHIR `string` cannot be empty
+        kwargs["name"] = str(name)
+    if raw_type is not None:
+        kwargs["type"] = [{"text": str(raw_type)}]
+        kwargs["extension"] = [X.ext_string(X.EXT_ORG_RAW_TYPE, raw_type)]
+    return Organization(**kwargs)
+
+
+def source_organization() -> Organization:
+    """The recording system/facility, referenced as Observation.performer when no
+    individual practitioner is captured. Served by the read route so the
+    performer reference resolves."""
+    oid = ID.source_organization_id()
+    return Organization(
+        id=oid,
+        identifier=[ID.identifier(ID.sys_organization(), oid)],
+        name="Recording system (EHR source)",
+        text=N.text("Recording system (EHR source)"),
+    )
+
+
+def to_internal(org: Organization) -> dict:
+    return {
+        "id": org.id,
+        "name": org.name if org.name is not None else "",
+        "type": X.get_ext(org.extension, X.EXT_ORG_RAW_TYPE),
+    }
+
+
+def to_upsert_row(org: Organization) -> dict:
+    return to_internal(org)

--- a/fabric/src/fhirgw/mappers/patient.py
+++ b/fabric/src/fhirgw/mappers/patient.py
@@ -1,0 +1,41 @@
+"""patient_token <-> FHIR Patient (PSEUDONYMOUS — identifier only, never any PHI).
+
+Hospilot has no patient table; PHI lives in CarerOS. The FHIR Patient is a
+referenceable anchor carrying only the opaque token, tagged PSEUDED (pseudonymized).
+
+NOT LIVE in fabric/: no caller in src/ (only the also-dead views.py references
+this module). Fabric's live inbound path, transform.py's patient(), reads full
+demographics directly off the FHIR Patient CarerOS sends — it does not use this
+mapper or its pseudonymization. The pseudonymized-Patient behavior described
+here is real, but only in agentic-framework's separate copy of fhirgw, where
+patient_token_to_patient() backs the live GET /fhir/Patient endpoint.
+"""
+
+from fhir.resources.patient import Patient
+
+from fhirgw import identifiers as ID, terminology as T, narrative as N
+
+
+def patient_token_to_patient(token: str) -> Patient:
+    return Patient(
+        id=str(token),
+        identifier=[ID.patient_identifier(token)],
+        meta={"security": [{"system": T.SYS_SECURITY,
+                            "code": T.PSEUD_SECURITY_LABEL[0], "display": T.PSEUD_SECURITY_LABEL[1]}]},
+        text=N.text(f"Pseudonymized patient {token}"),
+    )
+
+
+# alias matching the mapper naming convention
+def to_fhir(token: str) -> Patient:
+    return patient_token_to_patient(token)
+
+
+def to_internal(patient: Patient) -> dict:
+    token = None
+    for i in (patient.identifier or []):
+        sys = i.get("system") if isinstance(i, dict) else getattr(i, "system", None)
+        if sys == ID.sys_patient_token():
+            token = i.get("value") if isinstance(i, dict) else getattr(i, "value", None)
+            break
+    return {"patient_token": token or patient.id}

--- a/fabric/src/fhirgw/mappers/servicerequest.py
+++ b/fabric/src/fhirgw/mappers/servicerequest.py
@@ -1,0 +1,38 @@
+"""lab order -> FHIR ServiceRequest (read-only; used by lab_agent).
+
+Inbound from CarerOS, ServiceRequest is parsed directly by `fhir.resources`; this
+mapper only builds one from a local `hospilot_lab_orders` row for the Hasura
+fallback. R5 `ServiceRequest.code` is a CodeableReference (`concept`).
+
+NOT LIVE in fabric/: no caller in src/ invokes to_fhir() — the "used by
+lab_agent" / Hasura-fallback claim describes agentic-framework's copy of this
+file, not this one. This module has no to_internal() either; ServiceRequests
+are parsed directly from CarerOS's FHIR feed (fhir_client.py, transform.py),
+not through this mapper.
+"""
+
+from fhir.resources.servicerequest import ServiceRequest
+
+from fhirgw import terminology as T
+from fhirgw.mappers._common import parse_dt_safe
+
+_PRIORITY_MAP = {"STAT": "stat", "Urgent": "urgent", "Routine": "routine"}
+_STATUS_MAP = {"Pending": "active", "In Progress": "on-hold", "Completed": "completed"}
+
+
+def to_fhir(row: dict) -> ServiceRequest:
+    kwargs: dict = {
+        "id": str(row["id"]),
+        "status": _STATUS_MAP.get(row.get("status"), "active"),
+        "intent": "order",
+        "category": [{"coding": [{"system": T.SYS_OBS_CATEGORY, "code": "laboratory"}]}],
+        "code": {"concept": {"text": row.get("test_name") or "Lab order"}},
+        # R5 ServiceRequest.subject is required
+        "subject": {"reference": f"Patient/{row.get('patient_token') or 'unknown'}"},
+    }
+    if row.get("priority"):
+        kwargs["priority"] = _PRIORITY_MAP.get(row["priority"], "routine")
+    authored = parse_dt_safe(row.get("ordered_at") or row.get("created_at"))
+    if authored:
+        kwargs["authoredOn"] = authored
+    return ServiceRequest(**kwargs)

--- a/fabric/src/fhirgw/mappers/task.py
+++ b/fabric/src/fhirgw/mappers/task.py
@@ -1,0 +1,38 @@
+"""nursing task <-> FHIR Task (read-only; used by staff/discharge/notification).
+
+Inbound from CarerOS the Task is parsed directly by `fhir.resources`; this mapper
+only builds Task from local `hospilot_nursing_tasks` rows for the Hasura fallback.
+
+NOT LIVE in fabric/: no caller in src/ invokes to_fhir() — the Hasura fallback
+this docstring describes is not wired up. Nothing in this module is used on the
+inbound path either (unlike location/encounter/observation/organization, Task
+has no to_internal()).
+"""
+
+from fhir.resources.task import Task
+
+from fhirgw.mappers._common import parse_dt_safe
+
+# hospilot status (`completed` bool / status string) is collapsed: incomplete rows
+# come from queries that already filter completed=false, so they're 'requested'.
+_STATUS_MAP = {
+    "pending": "requested", "open": "requested", "requested": "requested",
+    "in_progress": "in-progress", "in-progress": "in-progress",
+    "completed": "completed", "done": "completed", "cancelled": "cancelled",
+}
+
+
+def to_fhir(row: dict) -> Task:
+    raw_status = str(row.get("status") or "").lower()
+    kwargs: dict = {
+        "id": str(row["id"]),
+        "status": _STATUS_MAP.get(raw_status, "requested"),
+        "intent": "order",
+        "description": row.get("task") or row.get("description") or "Nursing task",
+    }
+    if row.get("admission_id"):
+        kwargs["for"] = {"reference": f"Encounter/{row['admission_id']}"}
+    due = parse_dt_safe(row.get("due_at") or row.get("scheduled_at"))
+    if due:
+        kwargs["executionPeriod"] = {"start": due}
+    return Task(**kwargs)

--- a/fabric/src/fhirgw/narrative.py
+++ b/fabric/src/fhirgw/narrative.py
@@ -1,0 +1,19 @@
+"""Generated text narratives (FHIR dom-6 best practice).
+
+Every DomainResource "should have narrative for robust management". We emit a
+minimal machine-generated XHTML summary built purely from the structured data,
+so `status` is always 'generated' (no human-authored text mixed in).
+
+Narrative is write-only: the to_internal mappers never read `.text`, so adding
+it does not affect round-trip identity.
+"""
+
+import html
+
+XHTML_NS = "http://www.w3.org/1999/xhtml"
+
+
+def text(summary: str) -> dict:
+    """A FHIR Narrative wrapping `summary` as escaped XHTML."""
+    safe = html.escape(summary) if summary else "—"
+    return {"status": "generated", "div": f'<div xmlns="{XHTML_NS}">{safe}</div>'}

--- a/fabric/src/fhirgw/serialization.py
+++ b/fabric/src/fhirgw/serialization.py
@@ -1,0 +1,71 @@
+"""
+Serialize fhir.resources models into HTTP responses with the correct FHIR media
+type. We pre-serialize to a JSON string and hand Starlette raw bytes so FastAPI
+never re-encodes the model (which would emit application/json) and we never
+double-encode a JSON string via JSONResponse.
+
+Outbound responses use the "public" view: the Hospilot-proprietary extensions
+(EXT_BASE) are stripped so external consumers / validators get clean, standard
+FHIR with no Implementation Guide to load. The internal FHIR mirror (poller
+dual-write) keeps the extensions for lossless round-trip — it serializes models
+directly, not via this module.
+
+NOT LIVE in fabric/: no caller in src/ imports this module. Fabric's mounted
+/fhir route (api/fhir.py) serves plain FastAPI JSONResponse, not this module's
+fhir_response(). The equivalent live outbound serialization is
+agentic-framework's separate copy of fhirgw/serialization.py, used by its
+mounted /fhir route (api/routes/fhir.py).
+"""
+
+import json
+
+from starlette.responses import Response
+
+from fhirgw.extensions import EXT_BASE
+
+FHIR_MEDIA_TYPE = "application/fhir+json"
+
+
+def fhir_json(resource) -> str:
+    """Canonical FHIR JSON string: FHIR field names (aliases), no null fields."""
+    return resource.model_dump_json(exclude_none=True, by_alias=True)
+
+
+def _strip_hospilot_extensions(node):
+    """Recursively drop any extension whose url is a Hospilot canonical (EXT_BASE).
+
+    Standard FHIR extensions (none today) are preserved; this only removes the
+    `https://hospilot.carer.ai/...` enrichment/round-trip extensions.
+    """
+    if isinstance(node, dict):
+        ext = node.get("extension")
+        if isinstance(ext, list):
+            kept = [e for e in ext if not str(e.get("url", "")).startswith(EXT_BASE)]
+            if kept:
+                node["extension"] = kept
+            else:
+                node.pop("extension", None)
+        for value in node.values():
+            _strip_hospilot_extensions(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_hospilot_extensions(item)
+    return node
+
+
+def fhir_json_public(resource) -> str:
+    """Outbound JSON: canonical FHIR with Hospilot-proprietary extensions removed."""
+    data = json.loads(fhir_json(resource))
+    _strip_hospilot_extensions(data)
+    return json.dumps(data, separators=(",", ":"))
+
+
+def fhir_response(resource, status_code: int = 200, headers: dict | None = None,
+                  public: bool = False) -> Response:
+    content = fhir_json_public(resource) if public else fhir_json(resource)
+    return Response(
+        content=content,
+        media_type=FHIR_MEDIA_TYPE,
+        status_code=status_code,
+        headers=headers,
+    )

--- a/fabric/src/fhirgw/terminology.py
+++ b/fabric/src/fhirgw/terminology.py
@@ -1,0 +1,140 @@
+"""
+Terminology: code systems and the maps that turn Hospilot's plain strings/enums
+into FHIR codings (and back, for search). This module is the single source of
+truth for systems + codes used by both the mappers and the outbound API.
+"""
+
+# ─── Code systems ────────────────────────────────────────────────────────────
+SYS_LOINC                 = "http://loinc.org"
+SYS_SNOMED                = "http://snomed.info/sct"
+SYS_UCUM                  = "http://unitsofmeasure.org"
+SYS_OBS_CATEGORY          = "http://terminology.hl7.org/CodeSystem/observation-category"
+SYS_INTERPRETATION        = "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+SYS_ENCOUNTER_CLASS       = "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+SYS_LOCATION_PHYSICAL     = "http://terminology.hl7.org/CodeSystem/location-physical-type"
+SYS_LOCATION_OPER_STATUS  = "http://terminology.hl7.org/CodeSystem/v2-0116"
+SYS_ORG_TYPE              = "http://terminology.hl7.org/CodeSystem/organization-type"
+SYS_SECURITY              = "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"
+# Pseudonymization security label (member of the All Security Labels value set).
+# Code is PSEUDED in v3-ObservationValue — NOT "PSEUD" in v3-ActReason (invalid).
+PSEUD_SECURITY_LABEL      = ("PSEUDED", "pseudonymized")
+
+# ─── Observation categories ───────────────────────────────────────────────────
+OBS_CAT_VITAL_SIGNS = "vital-signs"
+OBS_CAT_LABORATORY  = "laboratory"
+
+# ─── Vital signs LOINC: hospilot field -> (code, display, UCUM unit) ──────────
+# Field names match the internal vitals projection (see poller _map_vital).
+VITALS_LOINC: dict[str, tuple[str, str, str]] = {
+    "temperature":      ("8310-5",  "Body temperature",  "Cel"),
+    "pulse":            ("8867-4",  "Heart rate",        "/min"),
+    "respiratory_rate": ("9279-1",  "Respiratory rate",  "/min"),
+    "spo2":             ("59408-5", "Oxygen saturation in Arterial blood by Pulse oximetry", "%"),
+    "gcs":              ("9269-2",  "Glasgow coma score total", "{score}"),
+}
+# Blood pressure is a panel with two components.
+BP_PANEL_CODE   = ("85354-9", "Blood pressure panel with all children optional")
+BP_SYSTOLIC     = ("8480-6",  "Systolic blood pressure",  "mm[Hg]")
+BP_DIASTOLIC    = ("8462-4",  "Diastolic blood pressure", "mm[Hg]")
+
+# The FHIR `oxygensat` profile requires the "magic" LOINC code 2708-6 to be
+# present on Observation.code (it rejects the resource otherwise) and that code
+# — not the pulse-ox code 59408-5 — is the one in the Vital Signs value set. We
+# carry both: our specific pulse-ox code first (so round-trip keys off it) plus
+# the required magic code. Map of primary LOINC -> extra required (code, display).
+VITAL_REQUIRED_CODINGS: dict[str, tuple[str, str]] = {
+    "59408-5": ("2708-6", "Oxygen saturation in Arterial blood"),
+}
+
+# GCS total is a unit-less integer score. Emitting it as a Quantity forces a
+# UCUM annotation like {score}, which the validator warns is misleading, so we
+# emit valueInteger instead (9269-2 is not one of the profiled vital codes).
+GCS_CODE = "9269-2"
+
+# Set of LOINC codes that belong to a single vitals reading (for /fhir read by id)
+VITALS_CODES = {c for c, _d, _u in VITALS_LOINC.values()} | {
+    BP_PANEL_CODE[0], BP_SYSTOLIC[0], BP_DIASTOLIC[0],
+}
+
+# ─── Lab interpretation: hospilot `flag` -> (code, display) ───────────────────
+INTERPRETATION_MAP: dict[str, tuple[str, str]] = {
+    "Normal":   ("N",  "Normal"),
+    "Low":      ("L",  "Low"),
+    "High":     ("H",  "High"),
+    "Critical": ("HH", "Critical high"),
+}
+# Vital `is_critical` flag -> interpretation
+CRITICAL_INTERP = ("AA", "Critical abnormal")
+
+# ─── Encounter status: internal (lowercased) -> FHIR Encounter.status (R5) ────
+# R5 EncounterStatus value set: planned | in-progress | on-hold | discharged |
+# completed | cancelled | discontinued | entered-in-error | unknown.
+# (R4's arrived/triaged/finished were removed in R5.) The raw internal status is
+# preserved in an extension, so this lossy mapping never breaks the round-trip.
+# Admissions: admitted | discharging | discharged
+# ER visits:  waiting | triaged | in_treatment | admitted | discharged
+ENCOUNTER_STATUS_MAP: dict[str, str] = {
+    "admitted":     "in-progress",
+    "discharging":  "discharged",   # patient being discharged; encounter finalizing
+    "in_treatment": "in-progress",
+    "discharged":   "completed",
+    "waiting":      "in-progress",  # R5 has no 'arrived'; the encounter has begun
+    "triaged":      "in-progress",  # R5 has no 'triaged'
+    "cancelled":    "cancelled",
+}
+_FHIR_TO_INTERNAL_ENCOUNTER_STATUS = {
+    "in-progress": ["admitted", "in_treatment", "waiting", "triaged"],
+    "discharged":  ["discharging"],
+    "completed":   ["discharged"],
+    "cancelled":   ["cancelled"],
+}
+
+
+def encounter_status_to_fhir(internal_status: str | None) -> str:
+    return ENCOUNTER_STATUS_MAP.get((internal_status or "").lower(), "unknown")
+
+
+def encounter_status_to_internal(fhir_status: str) -> list[str]:
+    """Reverse map for ?status= search (one FHIR status may match several internal)."""
+    return _FHIR_TO_INTERNAL_ENCOUNTER_STATUS.get(fhir_status, [fhir_status])
+
+
+# ─── Encounter class (v3-ActCode) ─────────────────────────────────────────────
+ENCOUNTER_CLASS_IMP  = {"system": SYS_ENCOUNTER_CLASS, "code": "IMP",  "display": "inpatient encounter"}
+ENCOUNTER_CLASS_EMER = {"system": SYS_ENCOUNTER_CLASS, "code": "EMER", "display": "emergency"}
+
+# ─── Location operational status (HL7 v2-0116) from bed `status` string ───────
+# Hospilot bed statuses: Available | Occupied | reserved | vacating | Dirty | Cleaning
+LOCATION_OPER_STATUS: dict[str, tuple[str, str]] = {
+    "available": ("U", "Unoccupied"),
+    "occupied":  ("O", "Occupied"),
+    "reserved":  ("O", "Occupied"),
+    "vacating":  ("O", "Occupied"),
+    "dirty":     ("K", "Contaminated"),
+    "cleaning":  ("H", "Housekeeping"),
+}
+
+
+def location_status(is_active: bool, bed_status: str | None) -> str:
+    """FHIR Location.status: active | suspended | inactive."""
+    if not is_active:
+        return "inactive"
+    if (bed_status or "").lower() in ("dirty", "cleaning"):
+        return "suspended"
+    return "active"
+
+
+def operational_status(bed_status: str | None) -> tuple[str, str] | None:
+    return LOCATION_OPER_STATUS.get((bed_status or "").lower())
+
+
+# ─── Triage (CTAS 1-5) -> FHIR Encounter.priority (very rough) ────────────────
+# CTAS 1 (resuscitation) is most urgent; FHIR priority uses ActPriority codes.
+TRIAGE_PRIORITY: dict[int, tuple[str, str]] = {
+    1: ("EM", "emergency"),
+    2: ("UR", "urgent"),
+    3: ("UR", "urgent"),
+    4: ("R",  "routine"),
+    5: ("R",  "routine"),
+}
+SYS_ACT_PRIORITY = "http://terminology.hl7.org/CodeSystem/v3-ActPriority"

--- a/fabric/src/fhirgw/views.py
+++ b/fabric/src/fhirgw/views.py
@@ -1,0 +1,20 @@
+"""
+Projection bridge: FHIR resource -> the internal dict agents consume.
+
+The poller uses these to build the Redis projection from canonical FHIR, so the
+agent-facing shape is *derived from FHIR* yet identical to today's keys. Anything
+holding a FHIR resource can get the agent dict in one call.
+
+NOT LIVE in fabric/: no caller in src/ imports this module (poller.py/sync_map.py
+call service.transform directly instead, which has its own copies of this
+projection logic; this module's own "the poller uses these" claim is stale).
+"""
+
+from fhirgw.mappers import location, organization, encounter, observation, patient
+
+bed_view = location.to_internal
+org_view = organization.to_internal
+admission_view = encounter.admission_to_internal
+visit_view = encounter.visit_to_internal
+vitals_view = observation.vitals_to_internal
+patient_view = patient.to_internal

--- a/fabric/src/ingest/__init__.py
+++ b/fabric/src/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Outbound ingest/streaming pipeline — turns DB changes into Kafka events.
+
+Background subsystem started in main.py's lifespan (only when Kafka is configured).
+Not part of the request-driven service layer; depends downward on service.* + clients.*
+"""

--- a/fabric/src/ingest/diff_poller.py
+++ b/fabric/src/ingest/diff_poller.py
@@ -1,0 +1,216 @@
+"""Polling-mode ingest — field-level diff over the DB's per-resource APIs.
+
+The alternative to the change_api poller (poller.py). Used when the DB exposes NO
+`$changed-resources` change feed: Fabric polls each per-resource FHIR-compliant API
+itself (the same reads it serves, in service/clinical.py), remembers the last value of
+each mutable column per record, and publishes only WHAT CHANGED:
+
+  • new record         → full row,  operation="upsert"  (same shape as change_api)
+  • mutable col changed → only the changed columns, operation="patch", changed=[...]
+  • unchanged          → nothing
+
+Each entity polls on its OWN cadence (settings.poll_intervals_ms / poll_interval_rest_ms)
+as an independent asyncio task, so a slow upstream for one entity never stalls the others.
+
+The write direction (snapshot/pending-changes) is unchanged and common to both modes.
+Vitals are NOT polled here (fetched at runtime). lab_result is polled via the keyset
+/sync/lab_result API (FHIR labs are patient-scoped). Deletes are not emitted in polling
+mode — a record leaving a filtered query is a status transition, not a delete; consumers
+rely on terminal-status patches + TTL (same as the change_api REST diff).
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from config import settings
+from service import clinical, initial_sync, sync_map
+from ingest import kafka_publisher as kafka
+from service import transform as tx
+from ingest.poller import _hash       # reuse the REST content-hash helper
+
+logger = logging.getLogger("poller")
+
+_LAB_RESULT_MAX_PAGES = 1000           # safety cap for the keyset loop
+
+# (entity, record_id) -> last-published projection of the tracked columns
+# (clinical: {col: value}; REST full-row entities: {"__hash__": sha1}).
+_seen: dict[tuple[str, str], dict] = {}
+
+
+def reset_cache() -> None:
+    """Drop the last-seen cache (used by tests; in prod the cache is process-lived)."""
+    _seen.clear()
+
+
+@dataclass(frozen=True)
+class DiffEntity:
+    entity: str                                      # Kafka topic suffix, e.g. "bed"
+    fetch: Callable[[], Awaitable[list[dict]]]       # existing list coroutine (reused)
+    mutable_cols: tuple[str, ...] | None             # tracked cols; None => full-row hash diff (REST)
+    id_key: str = "id"
+
+
+# ─── local fetch wrappers (reuse clinical.py; no fetch logic rewritten) ───────────
+def _dedup_by_id(rows: list[dict]) -> list[dict]:
+    out, seen = [], set()
+    for r in rows:
+        rid = r.get("id")
+        if rid in seen:
+            continue
+        seen.add(rid)
+        out.append(r)
+    return out
+
+
+async def _fetch_beds() -> list[dict]:
+    """Active + suspended (dirty) beds, so an Available↔Dirty transition is a status
+    change on a present record rather than a disappear/reappear."""
+    active = await clinical.beds()
+    dirty = await clinical.dirty_beds()
+    return _dedup_by_id([*active, *dirty])
+
+
+async def _fetch_tasks() -> list[dict]:
+    """Requested + overdue tasks (a completed task drops out of both — completion isn't
+    observable in polling mode; consumers rely on TTL)."""
+    inc = await clinical.incomplete_tasks()
+    over = await clinical.overdue_tasks()
+    return _dedup_by_id([*inc, *over])
+
+
+async def _fetch_patients() -> list[dict]:
+    """All patients — new arrivals publish as upserts to hospilot.data.patient.
+    The backend data_consumer matches the phone field to resume paused registrations."""
+    return await clinical.all_patients()
+
+
+async def _fetch_lab_results() -> list[dict]:
+    """Walk every keyset page of /sync/lab_result and normalize raw rows to the
+    lab_result contract (same shape the change_api feed emits)."""
+    rows: list[dict] = []
+    cursor: str | None = None
+    sync_id: str | None = None
+    seen_cursors: set[str] = set()
+    for _ in range(_LAB_RESULT_MAX_PAGES):
+        env = await initial_sync.page("lab_result", limit=200, cursor=cursor, sync_id=sync_id)
+        sync_id = sync_id or env.get("sync_id")
+        rows.extend(env.get("rows") or [])
+        pag = env.get("pagination") or {}
+        nxt = pag.get("next_cursor")
+        if not pag.get("has_more") or not nxt or nxt in seen_cursors:
+            break
+        seen_cursors.add(nxt)
+        cursor = nxt
+    return [tx.lab_result_row(r) for r in rows]
+
+
+# ─── registry ────────────────────────────────────────────────────────────────────
+CLINICAL_ENTITIES: list[DiffEntity] = [
+    DiffEntity("bed",        _fetch_beds,                ("status", "is_active")),
+    DiffEntity("admission",  clinical.all_admissions,
+               ("status", "discharge_ready", "discharge_blocked_reason", "transfer_pending", "bed_id")),
+    DiffEntity("visit",      clinical.er_visits,         ("status", "triage_score")),
+    DiffEntity("lab_order",  clinical.lab_orders,        ("status", "priority")),
+    DiffEntity("task",       _fetch_tasks,               ("status", "completed", "assigned_to")),
+    DiffEntity("lab_result", _fetch_lab_results,         ("result_value", "flag", "reported_at")),
+    # Full-row hash diff — publishes upsert on hospilot.data.patient for every new patient.
+    # The backend data_consumer matches the phone field to resume paused registration flows.
+    DiffEntity("patient",    _fetch_patients,            None),
+]
+
+
+def registry() -> list[DiffEntity]:
+    """Clinical entities (field-delta) + REST entities (full-row hash diff, reused from
+    sync_map.REST_ENTITIES so their contract is identical to change_api mode)."""
+    rest = [DiffEntity(entity, fetch, None) for entity, fetch in sync_map.REST_ENTITIES]
+    return [*CLINICAL_ENTITIES, *rest]
+
+
+# ─── diff + publish ────────────────────────────────────────────────────────────────
+def _project(e: DiffEntity, row: dict) -> dict:
+    if e.mutable_cols is None:
+        return {"__hash__": _hash(row)}
+    return {c: row.get(c) for c in e.mutable_cols}
+
+
+async def _maybe_discharge_ready(entity: str, rid: str, row: dict) -> None:
+    """Mirror the change_api fan-out: an admission with discharge_ready=true also
+    publishes the full row to the discharge_ready topic (sync_map _map_single)."""
+    if entity == "admission" and row.get("discharge_ready"):
+        await kafka.publish("discharge_ready", rid, row, operation="upsert")
+
+
+async def _emit_diff(e: DiffEntity, row: dict) -> bool:
+    """Publish a full upsert (new / REST change) or a field-level patch (clinical change).
+    Returns True iff an event was published. Cache is updated only after a successful
+    publish (at-least-once — a failure replays the record next cycle)."""
+    rid = str(row.get(e.id_key) or "")
+    if not rid:
+        return False
+    key = (e.entity, rid)
+    prev = _seen.get(key)
+    proj = _project(e, row)
+    if prev == proj:
+        return False
+    try:
+        if prev is None or e.mutable_cols is None:
+            # new record (cold start counts as new), or a REST full-row entity → full row
+            await kafka.publish(e.entity, rid, row, operation="upsert")
+        else:
+            changed = [c for c in e.mutable_cols if proj.get(c) != prev.get(c)]
+            await kafka.publish(e.entity, rid, {c: proj[c] for c in changed},
+                                operation="patch", changed=changed)
+        await _maybe_discharge_ready(e.entity, rid, row)
+    except Exception as exc:
+        logger.error("✗ publish %s/%s failed: %s", e.entity, rid, str(exc)[:160])
+        return False
+    _seen[key] = proj
+    return True
+
+
+async def _poll_entity(e: DiffEntity) -> None:
+    rows = await e.fetch()
+    published = 0
+    for row in rows:
+        if await _emit_diff(e, row):
+            published += 1
+    if published:
+        logger.info("→ [%s] %d change(s) published", e.entity, published)
+
+
+# ─── scheduling: one task per entity, each on its own cadence ──────────────────────
+def _interval_s(e: DiffEntity) -> float:
+    if e.mutable_cols is None:
+        ms = settings.poll_interval_rest_ms
+    else:
+        ms = settings.poll_intervals_ms.get(e.entity, settings.poll_interval_ms)
+    return ms / 1000
+
+
+async def _run_entity(e: DiffEntity) -> None:
+    interval = _interval_s(e)
+    logger.info("▶ diff poll [%s] every %.1fs  (cold start republishes full rows)", e.entity, interval)
+    while True:
+        try:
+            await _poll_entity(e)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("[%s] poll cycle error: %s", e.entity, str(exc)[:200])
+        await asyncio.sleep(interval)
+
+
+async def run() -> None:
+    """Spawn one poll loop per entity; cancel them all together on shutdown."""
+    entities = registry()
+    logger.info("▶ diff poller started (polling mode) — %d entities, per-entity cadence", len(entities))
+    tasks = [asyncio.create_task(_run_entity(e), name=f"diff-{e.entity}") for e in entities]
+    try:
+        await asyncio.gather(*tasks)
+    except asyncio.CancelledError:
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise

--- a/fabric/src/ingest/kafka_consumer.py
+++ b/fabric/src/ingest/kafka_consumer.py
@@ -1,0 +1,199 @@
+"""Kafka-mode ingest — event-triggered fetch-and-publish.
+
+When INTEGRATION_MODE=kafka, replaces the change_api / diff pollers.
+Subscribes to hospilot.changes.* (published by CarerOS Hasura event triggers),
+fetches the updated resource via FHIR (where possible), transforms it using the
+same tx.* functions the existing pollers use, and publishes to hospilot.data.*.
+
+Event payloads are used DIRECTLY wherever a raw-row mapper exists (service.transform
+`*_row`), so a cached entity costs no extra HTTP read — the event already carries the
+row. A re-read is issued only when there is no row mapper for the entity, when the
+event carried no `data`, or when the mapped row fails its completeness check (a field
+that lives on a join and therefore cannot come from a single-table payload).
+"""
+
+import asyncio
+import json
+import logging
+
+from aiokafka import AIOKafkaConsumer
+
+from clients import fhir_client as fc
+from config import settings
+from ingest import kafka_publisher as kafka
+from service import transform as tx
+
+logger = logging.getLogger("kafka_consumer")
+
+_CHANGE_TOPICS = [
+    f"hospilot.changes.{e}" for e in [
+        "bed", "admission", "ambulance", "dept",
+        "discharge_summary", "lab", "lab_result",
+        "lab_sample", "lab_analyzer", "pharmacy_order",
+        "pharmacy_inventory", "ot_room", "ot_room_status",
+        "ot_schedule", "ot_surgery", "task", "vital",
+    ]
+]
+
+
+# entity -> raw-row mapper. Present here == the event payload is authoritative and no
+# HTTP read is issued. Mirrors the normalized contracts in service.transform.
+_ROW_MAPPERS = {
+    "bed":                tx.bed_row,
+    "admission":          tx.admission_row,
+    "visit":              tx.visit_row,
+    "lab":                tx.lab_order_row,
+    "lab_result":         tx.lab_result_row,
+    "task":               tx.nursing_task_row,
+    "lab_sample":         tx.lab_sample_row,
+    "lab_analyzer":       tx.lab_analyzer_row,
+    "pharmacy_order":     tx.pharmacy_order_row,
+    "pharmacy_inventory": tx.pharmacy_inventory_row,
+}
+
+# Fields that cannot be derived from a single-table payload (they live on a relation in
+# the FHIR projection). If the mapped row leaves one empty we fall back to a re-read
+# rather than cache a half-populated record.
+_REQUIRED_FIELDS = {
+    "lab":            ("test_name",),   # lab_orders -> lab_results relation
+    "pharmacy_order": ("medication",),  # may be an FK to a drug master
+}
+
+
+def _from_payload(entity: str, raw_row: dict | None) -> dict | None:
+    """Map the event's own payload onto the normalized contract, or None if it cannot
+    be trusted (no mapper, no payload, no id, or a join-sourced field missing)."""
+    mapper = _ROW_MAPPERS.get(entity)
+    if mapper is None or not isinstance(raw_row, dict) or not raw_row:
+        return None
+    try:
+        row = mapper(raw_row)
+    except Exception as exc:
+        logger.warning("row-map %s failed: %s — falling back to a read", entity, str(exc)[:120])
+        return None
+    if not row.get("id"):
+        return None
+    missing = [f for f in _REQUIRED_FIELDS.get(entity, ()) if not row.get(f)]
+    if missing:
+        logger.info("payload for %s/%s lacks %s — re-reading", entity, row["id"], ",".join(missing))
+        return None
+    return row
+
+
+async def _fetch_normalized(entity: str, record_id: str, raw_row: dict | None) -> dict | None:
+    """Return the normalized dict for one record.
+
+    Preference order: the event's own payload (no network call) -> a targeted read of
+    that one record -> the raw row as-is."""
+    from_payload = _from_payload(entity, raw_row)
+    if from_payload is not None:
+        return from_payload
+    try:
+        if entity == "bed":
+            loc = await fc.read_location(f"bed-{record_id}")
+            return tx.bed(loc) if loc else None
+
+        if entity == "admission":
+            enc = await fc.read_encounter(f"ipd-{record_id}")
+            return tx.admission(enc) if enc else None
+
+        if entity == "dept":
+            orgs = await fc.search_organizations({"_id": record_id})
+            return tx.department(orgs[0]) if orgs else None
+
+        if entity == "lab_result":
+            obs = await fc.read_observation(f"lab-{record_id}")
+            return tx.lab_result(obs) if obs else None
+
+        if entity == "lab":
+            srs = await fc.search_service_requests({"_id": record_id})
+            return tx.lab_order(srs[0]) if srs else None
+
+        if entity == "task":
+            tasks = await fc.search_tasks({"_id": record_id})
+            return tx.nursing_task(tasks[0]) if tasks else None
+
+        if entity == "lab_sample":
+            specs = await fc.search_specimens({"_id": record_id})
+            return tx.lab_sample(specs[0]) if specs else None
+
+        if entity == "lab_analyzer":
+            devs = await fc.search_devices({"_id": record_id})
+            return tx.lab_analyzer(devs[0]) if devs else None
+
+        if entity == "pharmacy_order":
+            meds = await fc.search_medication_requests({"_id": record_id})
+            return tx.pharmacy_order(meds[0]) if meds else None
+
+        if entity == "pharmacy_inventory":
+            items = await fc.search_inventory_items({"_id": record_id})
+            return tx.pharmacy_inventory(items[0]) if items else None
+
+        # REST-backed entities (ambulance, ot_*, discharge_summary, vital):
+        # the raw DB row is published as-is — same approach as the REST diff poller.
+        return raw_row
+
+    except Exception as exc:
+        logger.warning("fetch %s/%s failed: %s — using raw row", entity, record_id, exc)
+        return raw_row
+
+
+# The DB's change feed calls this entity "lab" (matching hospilot.changes.lab),
+# but the rest of Fabric's ingest (sync_map.py, diff_poller.py) and the backend's
+# data_consumer._ROUTES key it as "lab_order". Remap on publish so kafka mode
+# lands on the same hospilot.data.* topic the other two modes use.
+_PUBLISH_ENTITY = {"lab": "lab_order"}
+
+
+async def _handle(entity: str, record_id: str, operation: str, raw_row: dict | None) -> None:
+    publish_entity = _PUBLISH_ENTITY.get(entity, entity)
+
+    if operation == "delete":
+        await kafka.publish(publish_entity, record_id, None, operation="delete")
+        return
+
+    data = await _fetch_normalized(entity, record_id, raw_row)
+    if data is None:
+        logger.warning("no data resolved for %s/%s — skipping publish", entity, record_id)
+        return
+
+    await kafka.publish(publish_entity, record_id, data)
+    logger.info("published %s/%s → hospilot.data.%s", entity, record_id, publish_entity)
+
+    # Mirror the discharge_ready fan-out that both existing pollers do
+    if entity == "admission" and data.get("discharge_ready"):
+        await kafka.publish("discharge_ready", record_id, data)
+
+
+async def run() -> None:
+    consumer = AIOKafkaConsumer(
+        *_CHANGE_TOPICS,
+        bootstrap_servers=settings.kafka_bootstrap_servers,
+        group_id="hospilot-fabric-changes",
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        auto_offset_reset="latest",
+    )
+    await consumer.start()
+    logger.info(
+        "▶ kafka consumer started — %d hospilot.changes.* topics", len(_CHANGE_TOPICS)
+    )
+    try:
+        async for msg in consumer:
+            try:
+                payload   = msg.value
+                entity    = payload.get("entity")
+                record_id = payload.get("id")
+                operation = payload.get("operation", "upsert")
+                raw_row   = payload.get("data")
+                if not entity or not record_id:
+                    continue
+                await _handle(entity, record_id, operation, raw_row)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("message handling error on %s: %s", msg.topic, exc)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await consumer.stop()
+        logger.info("kafka consumer stopped")

--- a/fabric/src/ingest/kafka_publisher.py
+++ b/fabric/src/ingest/kafka_publisher.py
@@ -1,0 +1,155 @@
+"""Kafka producer for publishing data-change events to hospilot-backend.
+
+Each event is `{entity, id, data}` published to topic `{prefix}.{entity}` and keyed
+by the record id (so per-record ordering is preserved). The `data` field is the full
+current row in Fabric's normalized shape — hospilot-backend consumes it and upserts
+Redis directly (see docs KAFKA_EVENT_CONTRACT).
+
+Disabled (no-op) when KAFKA_BOOTSTRAP_SERVERS is unset, so Fabric runs without Kafka
+in dev. `publish()` raises on delivery failure; the poller uses that to decide whether
+to acknowledge the DB change feed (at-least-once).
+"""
+
+import json
+import logging
+
+from config import settings
+
+logger = logging.getLogger("kafka")
+
+_producer = None
+
+
+def enabled() -> bool:
+    return settings.kafka_enabled
+
+
+async def start() -> None:
+    global _producer
+    if not enabled():
+        logger.info("✓ Kafka publishing OFF (no KAFKA_BOOTSTRAP_SERVERS)")
+        return
+    from aiokafka import AIOKafkaProducer
+
+    _producer = AIOKafkaProducer(
+        bootstrap_servers=settings.kafka_bootstrap_servers,
+        client_id=settings.kafka_client_id,
+        acks="all",
+        enable_idempotence=True,
+    )
+    await _producer.start()
+    logger.info("✓ Kafka producer connected  servers=%s prefix=%s",
+                settings.kafka_bootstrap_servers, settings.kafka_topic_prefix)
+
+
+async def stop() -> None:
+    global _producer
+    if _producer is not None:
+        await _producer.stop()
+        _producer = None
+
+
+async def publish(
+    entity: str,
+    record_id: str,
+    data: dict | None,
+    operation: str = "upsert",
+    changed: list[str] | None = None,
+) -> None:
+    """Publish one change event. Raises on delivery failure (caller decides on ack).
+
+    `operation` is "upsert" for full creates/updates, "delete" for removals, and
+    "patch" for polling-mode field-level diffs. For "delete", `data` is None —
+    consumers evict the record. For "patch", `data` carries ONLY the changed columns
+    and `changed` lists their names — consumers MERGE it onto existing state rather
+    than replacing the record. `changed` is omitted from the payload unless given, so
+    "upsert"/"delete" events keep their exact original shape.
+    """
+    if _producer is None:
+        return  # disabled — no-op
+    topic = f"{settings.kafka_topic_prefix}.{entity}"
+    payload = {"entity": entity, "id": record_id, "operation": operation, "data": data}
+    if changed is not None:
+        payload["changed"] = changed
+    await _producer.send_and_wait(
+        topic,
+        value=json.dumps(payload, default=str).encode("utf-8"),
+        key=str(record_id).encode("utf-8"),
+    )
+
+
+async def publish_ack(
+    *,
+    snapshot_id: str,
+    change_id: str,
+    entity: str,
+    record_id: str,
+    change_type: str,
+    status: str,
+    reason: str | None,
+    ts: str,
+) -> None:
+    """Publish one write-proposal acknowledgement to the dedicated ack topic.
+
+    `status` is "accepted" or "rejected". The backend consumes these to release the
+    optimistic lock it took when it issued the write (revert on "rejected"). Keyed by
+    `record_id` so a record's acks stay ordered. Raises on delivery failure so the
+    $confirm caller can keep the snapshot locked and let the DB retry. No-op when the
+    producer is disabled."""
+    if _producer is None:
+        return
+    payload = {
+        "snapshot_id": snapshot_id,
+        "change_id": change_id,
+        "entity": entity,
+        "id": record_id,
+        "change_type": change_type,
+        "status": status,
+        "reason": reason,
+        "ts": ts,
+    }
+    await _producer.send_and_wait(
+        settings.kafka_ack_topic,
+        value=json.dumps(payload, default=str).encode("utf-8"),
+        key=str(record_id).encode("utf-8"),
+    )
+
+
+async def publish_write_proposal(
+    *,
+    change_id: str,
+    entity: str,
+    record_id: str,
+    change_type: str,
+    http_method: str,
+    approval_needed: bool,
+    bundle: dict,
+    ts: str,
+) -> None:
+    """Publish one approved change to the DB over Kafka (integration_mode=kafka write leg).
+
+    The value is a thin envelope carrying a single-entry, spec-clean FHIR R5 transaction
+    `bundle` (built with include_approval=False, so approval lives here in the envelope,
+    not on the FHIR resource). Keyed by `record_id` (falls back to `change_id` when the
+    record id isn't known yet, e.g. appointment_create) so all changes to one record land
+    on one partition and stay ordered. Raises on delivery failure so the publisher loop
+    keeps the change queued (at-least-once); the DB dedups by change_id. No-op when the
+    producer is disabled (dev)."""
+    if _producer is None:
+        return
+    payload = {
+        "change_id": change_id,
+        "entity": entity,
+        "id": record_id,
+        "change_type": change_type,
+        "http_method": http_method,
+        "approval_needed": approval_needed,
+        "ts": ts,
+        "bundle": bundle,
+    }
+    key = record_id or change_id
+    await _producer.send_and_wait(
+        settings.kafka_write_topic,
+        value=json.dumps(payload, default=str).encode("utf-8"),
+        key=str(key).encode("utf-8"),
+    )

--- a/fabric/src/ingest/kafka_write_publisher.py
+++ b/fabric/src/ingest/kafka_write_publisher.py
@@ -1,0 +1,82 @@
+"""Kafka-mode write leg — push approved changes to the DB over Kafka.
+
+When INTEGRATION_MODE=kafka, the two-phase HTTP pull ($pending-changes/$acknowledge/
+$confirm) is replaced by this background loop: it drains the same in-memory ChangeStore
+the write endpoints enqueue into, resolves deferred ids (reusing bundle.resolve_changes,
+the exact logic the GET handler used), builds a single-entry FHIR R5 transaction Bundle
+per change, and publishes it to `hospilot.sync.write`. The DB consumes, applies, and
+produces an accepted/rejected ack to `hospilot.sync.ack` in the SAME shape Fabric's HTTP
+$confirm produced — so the main backend's ack consumer is unchanged and Fabric leaves the
+ack loop entirely.
+
+Delivery is at-least-once via a peek → publish → remove pattern (not drain → requeue):
+a change is dropped from the queue only after its proposal is durably sent, so a crash
+mid-loop re-offers it rather than losing it. The DB dedups by `change_id`. Per-record
+ordering holds because the producer keys by record_id (one partition per record) and this
+loop publishes in FIFO order, stopping on the first delivery failure.
+
+No snapshot / soft-lock is ever created in this mode (Kafka's durable log replaces it).
+"""
+
+import asyncio
+import logging
+
+from config import settings
+from fhirgw.bundle import build_snapshot_bundle, resolve_changes
+from ingest import kafka_publisher as kafka
+from service.change_store import get_change_store, now_iso
+
+logger = logging.getLogger("kafka_write")
+
+
+async def _drain_once() -> None:
+    store = get_change_store()
+    pending = await store.peek_pending()
+    if not pending:
+        return
+
+    resolved = await resolve_changes(pending)          # fills deferred ids; drops unresolvable
+    resolved_by_id = {c.change_id: c for c in resolved}
+    # Changes resolve_changes dropped (target doesn't exist) never publish — drop them from
+    # the queue too, matching the HTTP pull path (drain removed them there).
+    done_ids: set[str] = {c.change_id for c in pending if c.change_id not in resolved_by_id}
+
+    # Publish in FIFO order; a single-change bundle uses change_id as its snapshot_id so
+    # the DB's ack (snapshot_id == change_id) is byte-identical to the pull-path ack.
+    for change in resolved:
+        bundle = build_snapshot_bundle([change], change.change_id, include_approval=False)
+        try:
+            await kafka.publish_write_proposal(
+                change_id=change.change_id,
+                entity=change.entity,
+                record_id=change.record_id,
+                change_type=change.change_type,
+                http_method=change.http_method,
+                approval_needed=change.approval_needed,
+                bundle=bundle,
+                ts=now_iso(),
+            )
+            done_ids.add(change.change_id)
+            logger.info("→ proposed %s/%s → %s",
+                        change.entity, change.record_id or change.change_id,
+                        settings.kafka_write_topic)
+        except Exception as exc:  # delivery failure — keep this + the rest queued, retry next tick
+            logger.error("✗ propose %s/%s failed: %s — will retry",
+                         change.entity, change.record_id or change.change_id, str(exc)[:160])
+            break
+
+    await store.remove(done_ids)
+
+
+async def run() -> None:
+    interval = settings.write_drain_interval_ms / 1000
+    logger.info("▶ kafka write publisher started  interval=%.1fs  topic=%s",
+                interval, settings.kafka_write_topic)
+    while True:
+        try:
+            await _drain_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("write drain cycle error: %s", str(exc)[:200])
+        await asyncio.sleep(interval)

--- a/fabric/src/ingest/poller.py
+++ b/fabric/src/ingest/poller.py
@@ -1,0 +1,133 @@
+"""Background poller — turns DB changes into Kafka events.
+
+Runs as a single asyncio task (started in main.py lifespan, only when Kafka is
+configured). Each cycle:
+
+  1. FHIR feed  — GET the DB's `$changed-resources` Bundle, map each changed
+     resource to an event, publish, and acknowledge the feed ONLY if every event
+     published successfully (at-least-once; a failure replays the batch next cycle).
+  2. REST poll  — for endpoints with no change feed (OT / ambulance / appointments),
+     fetch the full list and publish only rows whose content hash changed since the
+     last cycle. A row is marked seen only after its event is published.
+
+Deletes are not published (the Redis consumer relies on TTLs — see the contract).
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+
+from clients import fhir_client as fc
+from config import settings
+from ingest import kafka_publisher as kafka
+from service import sync_map
+
+logger = logging.getLogger("poller")
+
+# REST diff state: (entity, row_id) -> content hash of the last published row.
+_seen: dict[tuple[str, str], str] = {}
+
+
+def _hash(row: dict) -> str:
+    return hashlib.sha1(json.dumps(row, sort_keys=True, default=str).encode()).hexdigest()
+
+
+async def _publish_all(events: list[tuple[str, str, dict]]) -> bool:
+    """Publish every event; return True only if all succeeded."""
+    ok = True
+    for entity, rid, data in events:
+        try:
+            await kafka.publish(entity, rid, data)
+        except Exception as exc:
+            ok = False
+            logger.error("✗ publish %s/%s failed: %s", entity, rid, str(exc)[:160])
+    return ok
+
+
+async def _poll_fhir_feed() -> None:
+    bundle = await fc.get_changed_resources()
+    entries = bundle.get("entry") or []
+    if not entries:
+        return
+
+    # Upserts: PUT/POST entries carry a full resource body.
+    resources = [
+        e["resource"] for e in entries
+        if e.get("resource") and (e.get("request") or {}).get("method") in ("PUT", "POST")
+    ]
+    upsert_events = sync_map.fhir_resources_to_events(resources)
+
+    # Deletes: the DB sends resource type + id + operation=DELETE; data is null.
+    delete_entries = [
+        e for e in entries
+        if (e.get("request") or {}).get("method") == "DELETE"
+    ]
+
+    if not upsert_events and not delete_entries:
+        # All-unmapped snapshot — ack so the DB clears it.
+        await fc.ack_changed_resources()
+        return
+
+    ok = True
+    published = 0
+    if upsert_events:
+        ok = await _publish_all(upsert_events)
+        if ok:
+            published += len(upsert_events)
+
+    for entry in delete_entries:
+        url = (entry.get("request") or {}).get("url", "")
+        for entity, rid in sync_map.fhir_delete_to_events(url):
+            try:
+                await kafka.publish(entity, rid, None, operation="delete")
+                published += 1
+            except Exception as exc:
+                ok = False
+                logger.error("✗ delete %s/%s failed: %s", entity, rid, str(exc)[:160])
+
+    if ok:
+        await fc.ack_changed_resources()
+        logger.info("→ %d clinical change(s) published & feed acked", published)
+    else:
+        logger.warning("⏳ publish failures — change feed NOT acked, retrying next cycle")
+
+
+async def _poll_rest() -> None:
+    published = 0
+    for entity, fetch in sync_map.REST_ENTITIES:
+        try:
+            rows = await fetch()
+        except Exception as exc:
+            logger.warning("REST %s fetch failed: %s", entity, str(exc)[:120])
+            continue
+        for row in rows:
+            rid = str(row.get("id") or "")
+            if not rid:
+                continue
+            h = _hash(row)
+            if _seen.get((entity, rid)) == h:
+                continue
+            try:
+                await kafka.publish(entity, rid, row)
+                _seen[(entity, rid)] = h     # mark seen only after a successful publish
+                published += 1
+            except Exception as exc:
+                logger.error("✗ publish %s/%s failed: %s", entity, rid, str(exc)[:160])
+    if published:
+        logger.info("→ %d REST change(s) published", published)
+
+
+async def run() -> None:
+    interval = settings.poll_interval_ms / 1000
+    logger.info("▶ change poller started  interval=%.1fs  feed=%s",
+                interval, settings.ehr_fhir_base_url)
+    while True:
+        try:
+            await _poll_fhir_feed()
+            await _poll_rest()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("poll cycle error: %s", str(exc)[:200])
+        await asyncio.sleep(interval)

--- a/fabric/src/logging_config.py
+++ b/fabric/src/logging_config.py
@@ -1,0 +1,96 @@
+"""
+Centralised logging setup for Hospilot backend.
+Run setup_logging() once at startup (main.py lifespan).
+"""
+import logging
+import sys
+
+# ANSI escape codes
+_R  = "\033[0m"      # reset
+_B  = "\033[1m"      # bold
+_DM = "\033[2m"      # dim
+_CY = "\033[36m"     # cyan
+_GR = "\033[32m"     # green
+_YL = "\033[33m"     # yellow
+_RD = "\033[31m"     # red
+_WH = "\033[97m"     # bright white
+_MG = "\033[35m"     # magenta
+
+_LEVEL_COLOR = {
+    "DEBUG":    _DM,
+    "INFO":     _CY,
+    "WARNING":  _YL,
+    "ERROR":    _RD,
+    "CRITICAL": _B + _RD,
+}
+
+# Map Python logger names to short display names (max 9 chars)
+_NAME_MAP = {
+    "guardrail":                            "GUARDRAIL",
+    "planner":                              "PLANNER  ",
+    "ranking":                              "RANKING  ",
+    "sessions":                             "SESSIONS ",
+    "approvals":                            "APPROVALS",
+    "kafka":                                "KAFKA    ",
+    "kafka.consumers.orchestrator":         "ORCHESTR.",
+    "kafka.consumers.bed_agent":            "BED_AGENT",
+    "poller.carerOS_poller":                "POLLER   ",
+    "db.hasura":                            "HASURA   ",
+    "cache.redis":                          "REDIS    ",
+    "__main__":                             "APP      ",
+    "uvicorn":                              "UVICORN  ",
+    "uvicorn.error":                        "UVICORN  ",
+    "temporal.workflow._condition_check":   "TASKGATE ",
+    "temporal.workflow.bed_agent_workflow": "BED_WF   ",
+    "temporal.workflow.er_agent_workflow":  "ER_WF    ",
+    "temporal.workflow.icu_agent_workflow": "ICU_WF   ",
+    "temporal.workflow.discharge_agent_workflow": "DISCH_WF ",
+    "temporal.workflow.revenue_agent_workflow":   "REV_WF   ",
+    "temporal.activities.bed_agent_activities":   "BED_ACT  ",
+    "temporal.activities.bed_activities":         "BED_ACT  ",
+    "temporal.activities.er_activities":          "ER_ACT   ",
+}
+
+
+class HospilotFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        time    = self.formatTime(record, "%H:%M:%S")
+        level   = record.levelname.ljust(7)
+        lcolor  = _LEVEL_COLOR.get(record.levelname, "")
+        name    = _NAME_MAP.get(record.name, record.name[:9].upper().ljust(9))
+        msg     = record.getMessage()
+
+        # Highlight key tokens
+        if record.levelname == "INFO":
+            msg = _highlight(msg)
+
+        line = f"{_DM}{time}{_R}  {lcolor}{level}{_R}  {_B}{_WH}{name}{_R}  {msg}"
+        if record.exc_info:
+            line += "\n" + self.formatException(record.exc_info)
+        return line
+
+
+def _highlight(msg: str) -> str:
+    """Colour-accent arrows and check marks to make scan-reading faster."""
+    msg = msg.replace("→", f"{_MG}→{_R}")
+    msg = msg.replace("←", f"{_GR}←{_R}")
+    msg = msg.replace("✓", f"{_GR}✓{_R}")
+    msg = msg.replace("✗", f"{_RD}✗{_R}")
+    msg = msg.replace("⏳", f"{_YL}⏳{_R}")
+    msg = msg.replace("▶", f"{_CY}▶{_R}")
+    return msg
+
+
+def setup_logging(level: str = "INFO") -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(HospilotFormatter())
+
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+    root.handlers.clear()
+    root.addHandler(handler)
+
+    # Silence noisy third-party loggers
+    for noisy in ("httpx", "httpcore", "aiokafka", "asyncio",
+                  "uvicorn.access", "kafka"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)

--- a/fabric/src/main.py
+++ b/fabric/src/main.py
@@ -1,0 +1,123 @@
+"""
+Hospilot-Fabric — transformation layer in front of the DB's APIs.
+
+Fabric is a CLIENT of the DB:
+  • it GETs canonical FHIR R5 from the DB's FHIR API (clinical), and calls the
+    DB's plain-REST financial API (billing), then
+  • transforms both into the normalized dict shapes the main backend wants, and
+  • serves them over a plain REST API (this app).
+
+If the DB's APIs change (or a different EHR/DB is integrated), only Fabric
+changes — the main backend keeps calling these normalized endpoints unchanged.
+"""
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
+
+from logging_config import setup_logging
+setup_logging()
+
+from config import settings
+
+logger = logging.getLogger("__main__")
+
+
+async def require_fabric_auth(request: Request) -> None:
+    """Guard Fabric's endpoints with a shared key (main app → Fabric)."""
+    key = settings.fabric_api_key
+    if not key:
+        return
+    auth = request.headers.get("authorization", "")
+    provided = auth[7:].strip() if auth[:7].lower() == "bearer " else request.headers.get("x-api-key")
+    if provided != key:
+        raise HTTPException(status_code=401, detail="Missing or invalid Fabric API key")
+
+
+from api.normalized import router as normalized_router
+from api.agents import router as agents_router
+from api.fhir import router as fhir_router
+from api.sync import router as sync_router
+from ingest import kafka_publisher as kafka
+from ingest import kafka_consumer
+from ingest import kafka_write_publisher
+from ingest import poller
+from ingest import diff_poller
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("▶ Hospilot-Fabric (transformation layer) starting  env=%s", settings.app_env)
+    logger.info("✓ upstream FHIR API      %s", settings.ehr_fhir_base_url)
+    logger.info("✓ upstream financial API %s", settings.financial_api_base_url)
+    logger.info("✓ upstream REST API      %s", settings.db_rest_base_url)
+    logger.info("✓ upstream sync API      %s", settings.sync_api_base_url)
+    logger.info("✓ Fabric auth=%s", "on" if settings.fabric_api_key else "OFF (dev)")
+
+    await kafka.start()
+    poll_task = None
+    write_task = None
+    if kafka.enabled():
+        if settings.kafka_mode:
+            logger.info("✓ ingest mode = KAFKA (event-triggered from hospilot.changes.*)")
+            poll_task = asyncio.create_task(kafka_consumer.run())
+        elif settings.polling_mode:
+            logger.info("✓ ingest mode = POLLING (per-entity field-level diff)")
+            poll_task = asyncio.create_task(diff_poller.run())
+        else:
+            logger.info("✓ ingest mode = CHANGE_API ($changed-resources feed)")
+            poll_task = asyncio.create_task(poller.run())
+        # Write direction: kafka mode PUSHES proposals; change_api/polling keep the
+        # HTTP $pending-changes pull (api/fhir.py stays active in those modes).
+        if settings.kafka_mode:
+            logger.info("✓ write mode = KAFKA → %s", settings.kafka_write_topic)
+            write_task = asyncio.create_task(kafka_write_publisher.run())
+        else:
+            logger.info("✓ write mode = HTTP PULL ($pending-changes)")
+    elif settings.polling_mode or settings.kafka_mode:
+        logger.warning("⚠ INTEGRATION_MODE=%s but Kafka disabled — no ingest started; "
+                       "writes fall back to the HTTP pull", settings.integration_mode)
+    else:
+        logger.info("✓ change poller OFF (Kafka disabled)")
+
+    logger.info("✓ Ready")
+    yield
+
+    for task in (poll_task, write_task):
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+    await kafka.stop()
+    logger.info("Hospilot-Fabric shutting down")
+
+
+app = FastAPI(
+    title="Hospilot-Fabric",
+    version="0.2.0",
+    description="Transformation layer: calls the DB's FHIR + financial APIs and serves normalized JSON.",
+    lifespan=lifespan,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origin_list,
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(normalized_router, dependencies=[Depends(require_fabric_auth)])
+app.include_router(agents_router, dependencies=[Depends(require_fabric_auth)])
+app.include_router(fhir_router, dependencies=[Depends(require_fabric_auth)])
+app.include_router(sync_router, dependencies=[Depends(require_fabric_auth)])
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "service": "hospilot-fabric", "env": settings.app_env}

--- a/fabric/src/service/ambulance.py
+++ b/fabric/src/service/ambulance.py
@@ -1,0 +1,10 @@
+from clients import rest_client as rc
+from config import settings
+
+
+def _base() -> str:
+    return settings.db_rest_base_url
+
+
+async def fleet() -> list[dict]:
+    return await rc.list_(_base(), "ambulance")

--- a/fabric/src/service/appointments.py
+++ b/fabric/src/service/appointments.py
@@ -1,0 +1,50 @@
+from clients import rest_client as rc
+from config import settings
+from service.change_store import PendingChange, get_change_store, new_change_id, now_iso
+from service.writes import CHANGE_TYPE_APPROVAL, CHANGE_TYPE_ENTITY
+
+
+def _base() -> str:
+    return settings.db_rest_base_url
+
+
+async def list_all(**filters) -> list[dict]:
+    return await rc.list_(_base(), "appointments", **filters)
+
+
+async def create(body: dict) -> dict:
+    # The DB assigns the appointment id, so record_id is unknown until $confirm returns
+    # it as `assigned_id`; the ack event fills `id` from there.
+    await get_change_store().add(PendingChange(
+        change_type="appointment_create",
+        resource_type="Appointment",
+        resource_id=None,
+        http_method="POST",
+        payload={"body": body},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["appointment_create"],
+        record_id="",
+        approval_needed=CHANGE_TYPE_APPROVAL["appointment_create"],
+    ))
+    return {"ok": True, "queued": True}
+
+
+async def slots(**filters) -> list[dict]:
+    return await rc.list_(_base(), "appointments/slots", **filters)
+
+
+async def book_slot(slot_id: str) -> dict:
+    await get_change_store().add(PendingChange(
+        change_type="slot_book",
+        resource_type="Slot",
+        resource_id=slot_id,
+        http_method="PATCH",
+        payload={},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["slot_book"],
+        record_id=str(slot_id),
+        approval_needed=CHANGE_TYPE_APPROVAL["slot_book"],
+    ))
+    return {"ok": True, "queued": True}

--- a/fabric/src/service/change_store.py
+++ b/fabric/src/service/change_store.py
@@ -1,0 +1,166 @@
+"""Pending-changes store — a single-in-flight snapshot state machine.
+
+Writes from the main app are queued here as PendingChanges. The DB drains them in
+a two-phase, soft-locked exchange:
+
+  1. GET  /fhir/Bundle/$pending-changes        — Fabric mints a snapshot_id, moves all
+     queued changes into the (single) in-flight snapshot (state "offered"), and returns
+     them as a FHIR Bundle. Re-pulling returns the SAME snapshot until it's resolved.
+  2. POST /fhir/Bundle/$pending-changes/$acknowledge {snapshot_id}
+     — receipt. Marks the snapshot "locked" (the soft lock is now held).
+  3. POST /fhir/Bundle/$pending-changes/$confirm {snapshot_id, results[]}
+     — the DB reports accepted/rejected per change. Fabric publishes one ack event per
+     change to Kafka and clears the snapshot (releases the lock).
+
+Only ONE snapshot is in flight at a time (the DB applies one batch before the next is
+offered). Writes that arrive while a snapshot is in flight queue up for the next pull.
+If the DB never confirms within `timeout_s`, the lock EXPIRES and the changes re-enter
+the queue (at-least-once) — see `current_inflight`.
+
+The GET handler resolves deferred ids (critical_vital, ai_discharge_note) OUTSIDE the
+store lock, then commits the resolved set via `commit_inflight`, so the in-flight
+snapshot and the Bundle reference the exact same change_ids.
+"""
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class PendingChange:
+    change_type: str       # "bed_status" | "triage_score" | "discharge_ready" | ...
+    resource_type: str     # FHIR type: "Encounter", "Location", "Observation", etc.
+    resource_id: str | None  # None when the ID must be resolved at bundle-build time
+    http_method: str       # "PATCH" | "POST"
+    payload: dict          # all data needed to build the Bundle entry
+    timestamp: str         # ISO 8601 UTC
+    change_id: str = field(default_factory=lambda: uuid.uuid4().hex)  # stable per-change id
+    entity: str = ""       # logical Kafka entity for the ack event ("bed", "visit", ...)
+    record_id: str = ""    # bare id the backend used (drives the ack event's `id`)
+    approval_needed: bool = False  # DB must route through approval before applying
+
+
+@dataclass
+class Snapshot:
+    snapshot_id: str
+    changes: list[PendingChange]
+    state: str             # "offered" (pulled, not yet acked) | "locked" (acked, awaiting confirm)
+    created_at: float      # time.monotonic() at offer
+    locked_at: float | None = None
+
+
+class SnapshotError(Exception):
+    """Raised when an $acknowledge/$confirm references an unknown/mismatched snapshot."""
+
+
+class ChangeStore:
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self._pending: list[PendingChange] = []
+        self._inflight: Snapshot | None = None
+
+    async def add(self, change: PendingChange) -> None:
+        async with self._lock:
+            self._pending.append(change)
+
+    async def peek_pending(self) -> list[PendingChange]:
+        """Return a snapshot of the queued changes WITHOUT removing them (kafka write
+        mode). The publisher resolves + publishes each, then calls `remove` for the ones
+        that delivered — so a crash mid-publish leaves changes queued (at-least-once)
+        rather than lost. Preserves FIFO order. Ignores the in-flight snapshot, which is
+        never used in kafka write mode (the HTTP pull is disabled there)."""
+        async with self._lock:
+            return list(self._pending)
+
+    async def remove(self, change_ids: set[str]) -> None:
+        """Drop the given changes from the queue by change_id (kafka write mode: called
+        after a proposal has been successfully published)."""
+        if not change_ids:
+            return
+        async with self._lock:
+            self._pending = [c for c in self._pending if c.change_id not in change_ids]
+
+    async def current_inflight(self, timeout_s: float) -> Snapshot | None:
+        """Return the live in-flight snapshot for an idempotent re-pull, or None if there
+        is none. If the in-flight snapshot has exceeded `timeout_s` without confirmation,
+        its changes are returned to the FRONT of the queue and None is returned (so the
+        caller offers a fresh snapshot)."""
+        async with self._lock:
+            if self._inflight is None:
+                return None
+            if time.monotonic() - self._inflight.created_at < timeout_s:
+                return self._inflight
+            self._pending = self._inflight.changes + self._pending   # expired: requeue
+            self._inflight = None
+            return None
+
+    async def drain_pending(self) -> list[PendingChange]:
+        """Atomically remove and return all queued (not-yet-offered) changes. Only valid
+        when no snapshot is in flight (the caller checks `current_inflight` first)."""
+        async with self._lock:
+            if self._inflight is not None:
+                return []
+            drained = self._pending
+            self._pending = []
+            return drained
+
+    async def commit_inflight(self, resolved: list[PendingChange]) -> Snapshot | None:
+        """Create the in-flight snapshot from the resolved change set. If resolution
+        dropped everything, returns None. If a snapshot raced in ahead of us, the resolved
+        changes are returned to the queue and the existing snapshot wins."""
+        async with self._lock:
+            if not resolved:
+                return None
+            if self._inflight is not None:
+                self._pending = resolved + self._pending
+                return self._inflight
+            snap = Snapshot(
+                snapshot_id=uuid.uuid4().hex,
+                changes=list(resolved),
+                state="offered",
+                created_at=time.monotonic(),
+            )
+            self._inflight = snap
+            return snap
+
+    async def mark_locked(self, snapshot_id: str) -> Snapshot:
+        """Receipt ($acknowledge): the DB has durably received the snapshot."""
+        async with self._lock:
+            if self._inflight is None or self._inflight.snapshot_id != snapshot_id:
+                raise SnapshotError(f"no in-flight snapshot {snapshot_id!r}")
+            self._inflight.state = "locked"
+            self._inflight.locked_at = time.monotonic()
+            return self._inflight
+
+    async def inflight_changes(self, snapshot_id: str) -> list[PendingChange]:
+        """Return the in-flight snapshot's changes for $confirm, WITHOUT releasing the
+        lock. The caller publishes acks first, then calls `release` only on success — so
+        a publish failure leaves the same snapshot (same id) locked for the DB to retry."""
+        async with self._lock:
+            if self._inflight is None or self._inflight.snapshot_id != snapshot_id:
+                raise SnapshotError(f"no in-flight snapshot {snapshot_id!r}")
+            return list(self._inflight.changes)
+
+    async def release(self, snapshot_id: str) -> None:
+        """Clear the in-flight snapshot (lock released) once its acks are published."""
+        async with self._lock:
+            if self._inflight is not None and self._inflight.snapshot_id == snapshot_id:
+                self._inflight = None
+
+
+_store = ChangeStore()
+
+
+def get_change_store() -> ChangeStore:
+    return _store
+
+
+def new_change_id() -> str:
+    return uuid.uuid4().hex
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/fabric/src/service/clinical.py
+++ b/fabric/src/service/clinical.py
@@ -1,0 +1,280 @@
+"""Clinical reads — orchestrate the DB's FHIR API + transform to normalized dicts.
+
+Each function calls the DB's FHIR endpoints (via clients.fhir_client), transforms
+the FHIR resources to the normal dict shapes the main backend wants (via
+service.transform), and joins/computes where the DB's FHIR can't (e.g. ICU
+membership from the bed→ward graph, simple aggregates).
+
+Note: the DB's default page size is 50, so list searches pass _count=200 (the
+server cap) to avoid silent truncation.
+"""
+
+from clients import fhir_client as fc
+from service import transform as tx
+
+PAGE = 200   # DB caps _count at 200
+
+
+# ─── beds ───────────────────────────────────────────────────────────────────────
+async def _location_index() -> tuple[dict[str, dict], dict[str, str]]:
+    """Active Locations → (beds_by_id, wards_by_id name map). Beds = form 'bd',
+    wards = form 'wa' (so partOf can resolve to a ward name)."""
+    locs = await fc.search_locations({"status": "active", "_count": PAGE})
+    beds_raw, wards = [], {}
+    for loc in locs:
+        form = loc.form.coding[0].code if (loc.form and loc.form.coding) else None
+        if form == "wa":
+            wards[loc.id] = loc.name
+        else:
+            beds_raw.append(loc)
+    beds = {}
+    for loc in beds_raw:
+        b = tx.bed(loc, wards_by_id=wards)
+        beds[b["id"]] = b
+    return beds, wards
+
+
+async def beds() -> list[dict]:
+    index, _ = await _location_index()
+    return list(index.values())
+
+
+async def available_icu_beds() -> list[dict]:
+    index, _ = await _location_index()
+    return [b for b in index.values() if tx.is_icu_bed(b) and (b.get("status") == "Available")]
+
+
+async def dirty_beds(icu_only: bool = False) -> list[dict]:
+    locs = await fc.search_locations({"status": "suspended", "_count": PAGE})
+    _, wards = await _location_index()
+    out = []
+    for loc in locs:
+        b = tx.bed(loc, wards_by_id=wards)
+        if icu_only and not tx.is_icu_bed(b):
+            continue
+        out.append(b)
+    return out
+
+
+async def beds_summary() -> dict:
+    index, _ = await _location_index()
+    all_beds = list(index.values())
+    icu = [b for b in all_beds if tx.is_icu_bed(b)]
+
+    def _avail(rows):
+        return [b for b in rows if b.get("status") == "Available"]
+
+    total, available = len(all_beds), len(_avail(all_beds))
+    icu_total, icu_avail = len(icu), len(_avail(icu))
+    return {
+        "total_beds": total,
+        "occupied_beds": total - available,
+        "available_beds": available,
+        "occupancy_pct": round((total - available) / max(total, 1) * 100),
+        "icu_total": icu_total,
+        "icu_occupied": icu_total - icu_avail,
+        "icu_available": icu_avail,
+        "icu_pct": round((icu_total - icu_avail) / max(icu_total, 1) * 100),
+    }
+
+
+# ─── admissions ─────────────────────────────────────────────────────────────────
+async def _admissions(params: dict) -> list[dict]:
+    encs = await fc.search_encounters({"class": "IMP", "_count": PAGE, **params})
+    index, _ = await _location_index()
+    out = []
+    for e in encs:
+        a = tx.admission(e)
+        bed = index.get(a.get("bed_id")) if a.get("bed_id") else None
+        if bed:
+            a["bed"] = {k: bed.get(k) for k in ("ward", "room_type", "ventilation", "features", "status")}
+        out.append(a)
+    return out
+
+
+async def all_admissions() -> list[dict]:
+    return await _admissions({})
+
+
+def _is_icu(a: dict) -> bool:
+    return bool(a.get("bed")) and "icu" in (a["bed"].get("ward") or "").lower()
+
+
+async def icu_admissions() -> list[dict]:
+    # exclude patients already pending transfer out (parity with the old query)
+    return [a for a in await _admissions({"status": "in-progress"})
+            if _is_icu(a) and not a.get("transfer_pending")]
+
+
+async def non_icu_admissions() -> list[dict]:
+    return [a for a in await _admissions({"status": "in-progress"})
+            if not _is_icu(a) and not a.get("transfer_pending")]
+
+
+async def admissions_with_wards() -> list[dict]:
+    return await _admissions({})
+
+
+async def discharge_ready_count() -> int:
+    return sum(1 for a in await _admissions({"status": "in-progress"}) if a.get("discharge_ready"))
+
+
+# ─── visits / ER ─────────────────────────────────────────────────────────────────
+_TERMINAL_VISIT = {"completed", "cancelled"}
+
+
+async def er_visits() -> list[dict]:
+    # The DB returns EMER visit status as "unknown" (source status not mapped), so we
+    # can't filter by ?status=in-progress — fetch all EMER and drop only terminal ones.
+    encs = await fc.search_encounters({"class": "EMER", "_count": PAGE})
+    visits = [tx.visit(e) for e in encs]
+    return [v for v in visits if (v.get("status") or "").lower() not in _TERMINAL_VISIT]
+
+
+async def er_pressure() -> dict:
+    visits = await er_visits()        # already active (non-terminal)
+    ctas_1_2 = sum(1 for v in visits if (v.get("triage_score") or 99) <= 2)
+    ctas_3 = sum(1 for v in visits if v.get("triage_score") == 3)
+    return {"ctas_1_2": ctas_1_2, "ctas_3": ctas_3, "est_admissions": ctas_1_2 + round(ctas_3 * 0.6)}
+
+
+# ─── vitals ───────────────────────────────────────────────────────────────────────
+async def latest_vitals(patient_token: str) -> dict | None:
+    obs = await fc.search_observations({"patient": patient_token, "category": "vital-signs", "_count": PAGE})
+    if not obs:
+        return None
+    readings = [r for r in (tx.vital(g) for g in tx.group_vitals_by_reading(obs).values()) if r]
+    if not readings:
+        return None
+    return max(readings, key=lambda r: (r.get("recorded_at") or ""))
+
+
+async def critical_vitals() -> list[dict]:
+    # DB supports the interpretation=AA filter (critical-alert flagged vitals)
+    obs = await fc.search_observations({"category": "vital-signs", "interpretation": "AA", "_count": PAGE})
+    readings = [r for r in (tx.vital(g) for g in tx.group_vitals_by_reading(obs).values()) if r]
+    return [r for r in readings if r.get("is_critical")]
+
+
+# ─── nursing tasks ────────────────────────────────────────────────────────────────
+async def incomplete_tasks() -> list[dict]:
+    # DB Task status: completed=false -> "requested", completed=true -> "completed"
+    tasks = await fc.search_tasks({"status": "requested", "_count": PAGE})
+    return [tx.nursing_task(t) for t in tasks]
+
+
+async def overdue_tasks() -> list[dict]:
+    tasks = await fc.search_tasks({"overdue": "true", "_count": PAGE})
+    return [tx.nursing_task(t) for t in tasks]
+
+
+async def nursing_tasks_for(admission_id: str, statuses: str = "requested") -> list[dict]:
+    # DB filters Task by the bare admission uuid via ?encounter=
+    tasks = await fc.search_tasks({"encounter": admission_id, "status": statuses, "_count": PAGE})
+    return [tx.nursing_task(t) for t in tasks]
+
+
+async def completed_task_count(admission_id: str) -> int:
+    tasks = await fc.search_tasks({"encounter": admission_id, "status": "completed", "_count": PAGE})
+    return len(tasks)
+
+
+# ─── labs ───────────────────────────────────────────────────────────────────────
+async def lab_orders() -> list[dict]:
+    # the DB's ServiceRequest status filter is an exact match (no comma-OR), so query
+    # each pending status separately and merge.
+    rows = []
+    for status in ("active", "on-hold"):
+        rows += await fc.search_service_requests({"status": status, "_count": PAGE})
+    return [tx.lab_order(r) for r in rows]
+
+
+async def lab_results(patient_token: str | None = None, test_code: str | None = None) -> list[dict]:
+    # The upstream FHIR API requires `patient` for category=laboratory — without it
+    # the DB returns 400, which propagates as a 500. Return empty rather than error.
+    if not patient_token:
+        return []
+    params = {"category": "laboratory", "_count": PAGE, "patient": patient_token}
+    if test_code:
+        params["code"] = test_code
+    obs = await fc.search_observations(params)
+    return [tx.lab_result(o) for o in obs]
+
+
+# ─── departments / patients ──────────────────────────────────────────────────────
+async def departments() -> list[dict]:
+    return [tx.department(o) for o in await fc.search_organizations({"_count": PAGE})]
+
+
+async def patient_tokens() -> list[str]:
+    return [t for t in (tx.patient_token(p) for p in await fc.search_patients({"_count": PAGE})) if t]
+
+
+async def patient(token: str) -> dict | None:
+    p = await fc.read_patient(token)
+    return tx.patient(p) if p else None
+
+
+async def patient_names(tokens: list[str]) -> dict[str, dict]:
+    """{token: {first_name, last_name, uhid, ...}} — matches db.hasura.get_patient_names."""
+    out: dict[str, dict] = {}
+    for t in tokens:
+        p = await fc.read_patient(t)
+        if p:
+            out[t] = tx.patient(p)
+    return out
+
+
+async def all_patients() -> list[dict]:
+    """All patients — used by the diff poller to detect newly registered patients."""
+    return [tx.patient(p) for p in await fc.search_patients({"_count": PAGE})]
+
+
+async def patient_by_mobile(mobile: str) -> dict:
+    """Resolve a patient from a mobile number.
+
+    Normalises to last 10 digits, searches FHIR Patient by phone, confirms the
+    match client-side (telecom digits must end with the queried digits), picks the
+    best candidate (active first, then most recently updated), and enriches with
+    the current in-progress ER encounter.
+    """
+    import re
+    digits = re.sub(r"\D", "", mobile)[-10:]
+    if not digits:
+        return {"exists": False}
+
+    candidates = await fc.search_patients_by_phone(digits)
+
+    def _matches(pat) -> bool:
+        for t in (getattr(pat, "telecom", None) or []):
+            v = re.sub(r"\D", "", getattr(t, "value", "") or "")
+            if v.endswith(digits):
+                return True
+        return False
+
+    confirmed = [p for p in candidates if _matches(p)]
+    if not confirmed:
+        return {"exists": False}
+
+    def _rank(p):
+        active = bool(getattr(p, "active", False))
+        meta = getattr(p, "meta", None)
+        lu = getattr(meta, "last_updated", None) if meta else None
+        return (int(active), str(lu) if lu else "")
+
+    best = sorted(confirmed, key=_rank, reverse=True)[0]
+    info = tx.patient(best)
+    token = info["patient_token"]
+
+    current_visit_id = None
+    try:
+        encs = await fc.search_encounters(
+            {"patient": token, "class": "EMER", "status": "in-progress", "_count": 1}
+        )
+        if encs:
+            from fhirgw.mappers._common import bare_id
+            current_visit_id = bare_id(encs[0].id)
+    except Exception:
+        pass
+
+    return {"exists": True, **info, "current_visit_id": current_visit_id}

--- a/fabric/src/service/financial.py
+++ b/fabric/src/service/financial.py
@@ -1,0 +1,86 @@
+"""Financial reads — thin wrappers over the DB's plain-REST financial API.
+
+These responses are already the dict shapes the revenue/billing agents want, so
+Fabric passes them straight through (no FHIR involved). See CarerOS-Financial-API-Spec.
+Uses the generic plain-REST client (clients.rest_client) bound to the financial base URL.
+"""
+
+import logging
+
+from clients import rest_client as rc
+from config import settings
+
+logger = logging.getLogger("financial")
+
+
+def _base() -> str:
+    return settings.financial_api_base_url
+
+
+async def invoices(payment_status=None, patient=None, invoice_type=None, limit=None, offset=None) -> list[dict]:
+    return await rc.list_(
+        _base(), "invoices",
+        payment_status=payment_status, patient=patient, invoice_type=invoice_type,
+        limit=limit, offset=offset,
+    )
+
+
+async def invoice_line_items(invoice_id: str) -> list[dict]:
+    return await rc.safe_list(_base(), f"invoices/{invoice_id}/line_items")
+
+
+async def claims(status=None, patient=None, visit_id=None, limit=None, offset=None) -> list[dict]:
+    return await rc.list_(
+        _base(), "claims",
+        status=status, patient=patient, visit_id=visit_id, limit=limit, offset=offset,
+    )
+
+
+async def claim_line_items(claim_id: str) -> list[dict]:
+    return await rc.list_(_base(), f"claims/{claim_id}/line_items")
+
+
+async def claim_history(claim_id: str) -> list[dict]:
+    return await rc.list_(_base(), f"claims/{claim_id}/history")
+
+
+async def claim_queries(claim_id: str) -> list[dict]:
+    return await rc.list_(_base(), f"claims/{claim_id}/queries")
+
+
+async def payments() -> list[dict]:
+    return await rc.list_(_base(), "payments")
+
+
+async def payment_entries(payment_id: str) -> list[dict]:
+    return await rc.safe_list(_base(), f"payments/{payment_id}/entries")
+
+
+async def refunds(invoice_id=None) -> list[dict]:
+    # Upstream nests refunds under payments: /api/financial/payments/refunds.
+    # A bare /refunds 404s, and safe_list turns that into [] — i.e. refunds silently
+    # look empty rather than erroring. Keep the path in step with the DB's spec.
+    return await rc.safe_list(_base(), "payments/refunds", invoice_id=invoice_id)
+
+
+async def contracts() -> list[dict]:
+    return await rc.list_(_base(), "contracts")
+
+
+async def contract_rates(contract_id: str) -> list[dict]:
+    return await rc.list_(_base(), f"contracts/{contract_id}/rates")
+
+
+async def collections(date: str) -> dict | None:
+    # tolerant: collections is empty/optional in the DB today
+    try:
+        return await rc.get_one(_base(), f"collections/{date}")
+    except Exception:
+        return None
+
+
+async def reconciliation(date: str) -> dict | None:
+    try:
+        return await rc.get_one(_base(), f"reconciliation/{date}")
+    except Exception:
+        return None

--- a/fabric/src/service/initial_sync.py
+++ b/fabric/src/service/initial_sync.py
@@ -1,0 +1,87 @@
+"""Initial-sync service: thin pass-through over the DB's keyset-paginated
+/api/sync/<table> endpoints.
+
+This is used ONCE by the main backend to populate Redis from scratch with a
+full dump of each table, before the Kafka change-feed mechanism takes over for
+incremental updates. Fabric does not transform these rows — it forwards the DB's
+raw rows + pagination envelope so the backend can mirror tables verbatim.
+
+The 14 syncable tables mirror the DB's sync registry. Keep this list in sync
+with INITIAL_SYNC_API.md / the DB's syncPaginator.js registry.
+"""
+
+from clients import sync_client
+
+# logical :table value -> source SQL table (for docs/observability; the DB owns
+# the authoritative registry). Order matches INITIAL_SYNC_API.md.
+TABLE_SOURCES: dict[str, str] = {
+    "admission": "hospilot.ipd_admissions",
+    "ambulance": "hospilot.emergency_ambulances",
+    "bed": "hospilot.beds",
+    "dept": "hospilot.departments",
+    "discharge_ready": "hospilot.ipd_admissions (discharge_ready = TRUE)",
+    "discharge_summary": "hospilot.discharge_summaries",
+    "lab": "hospilot.lab_orders",
+    "lab_result": "hospilot.lab_results",
+    "lab_sample": "hospilot.lab_samples",
+    "lab_analyzer": "hospilot.lab_analyzers",
+    "ot_room": "hospilot.ot_rooms",
+    "ot_room_status": "hospilot.ot_room_status",
+    "ot_schedule": "hospilot.ot_surgery_schedule",
+    "ot_surgery": "hospilot.ot_surgeries",
+    "pharmacy_order": "hospilot.pharmacy_orders",
+    "pharmacy_inventory": "hospilot.pharmacy_inventory",
+    "task": "hospilot.nursing_tasks",
+    "vital": "hospilot.vitals",
+    # HRMS / ICU tables (DATA_NEEDED). These rows exist in Postgres but the DB's sync
+    # registry must add /api/sync/<table> before they resolve — until then the forward
+    # returns the DB's 404 and the Kafka pollers (which drain these same pages) publish
+    # nothing. (ED has no table here — ER demand = EMER visits, already synced.)
+    "staff": "hospilot.staff",
+    "staff_roster": "hospilot.staff_roster",
+    "ventilator": "hospilot.ventilator",
+}
+
+TABLES: list[str] = list(TABLE_SOURCES)
+
+
+def is_valid_table(table: str) -> bool:
+    return table in TABLE_SOURCES
+
+
+async def page(
+    table: str,
+    *,
+    limit: int | None = None,
+    cursor: str | None = None,
+    sync_id: str | None = None,
+) -> dict:
+    """Fetch one keyset page for `table`, forwarding the DB's envelope as-is."""
+    return await sync_client.fetch_page(
+        table, limit=limit, cursor=cursor, sync_id=sync_id
+    )
+
+
+async def drain(table: str, *, page_size: int = 200, max_pages: int = 1000) -> list[dict]:
+    """Walk every keyset page of `table` and return all rows.
+
+    Lets the Kafka pollers source entities that have no FHIR feed and no plain-REST
+    list endpoint upstream — the same approach diff_poller uses for lab_result.
+    Raises httpx.HTTPStatusError if the DB hasn't registered /api/sync/<table> yet;
+    the pollers catch per-entity and retry next cycle (so it's inert, not fatal).
+    """
+    rows: list[dict] = []
+    cursor: str | None = None
+    sync_id: str | None = None
+    seen: set[str] = set()
+    for _ in range(max_pages):
+        env = await page(table, limit=page_size, cursor=cursor, sync_id=sync_id)
+        sync_id = sync_id or env.get("sync_id")
+        rows.extend(env.get("rows") or [])
+        pag = env.get("pagination") or {}
+        nxt = pag.get("next_cursor")
+        if not pag.get("has_more") or not nxt or nxt in seen:
+            break
+        seen.add(nxt)
+        cursor = nxt
+    return rows

--- a/fabric/src/service/lab.py
+++ b/fabric/src/service/lab.py
@@ -1,0 +1,60 @@
+"""Lab service layer.
+
+Two data access patterns:
+
+  • FHIR-backed (Redis)  — lab_samples (Specimen) + lab_analyzers (Device).
+    Fabric fetches from the DB's FHIR API, transforms, and these are also
+    published to Kafka via the change feed so the backend can warm Redis.
+
+  • REST pass-through (agent-direct) — qc_logs, reflex_rules, validation_rules,
+    capacity_history, critical_escalations. Fabric proxies the DB's plain-REST
+    /api/lab/* endpoints with no transformation.
+
+lab_orders and lab_results are served by clinical.py (FHIR Observation /
+ServiceRequest) and are already Redis-backed via the existing change feed.
+"""
+
+import logging
+
+from clients import fhir_client as fc
+from clients import rest_client as rc
+from config import settings
+from service import transform as tx
+
+logger = logging.getLogger("lab_service")
+
+_REST = lambda: settings.db_rest_base_url   # http://192.46.212.81:3001/api  # noqa: E731
+
+
+# ─── FHIR-backed (sync → Redis → agents read from Redis) ─────────────────────
+
+async def samples() -> list[dict]:
+    specimens = await fc.search_specimens({"_count": "200"})
+    return [tx.lab_sample(s) for s in specimens]
+
+
+async def analyzers() -> list[dict]:
+    devices = await fc.search_devices({"_count": "200"})
+    return [tx.lab_analyzer(d) for d in devices]
+
+
+# ─── REST pass-through (agents call Fabric, Fabric calls DB REST) ─────────────
+
+async def qc_logs(hours: int = 24) -> list[dict]:
+    return await rc.safe_list(_REST(), "lab/qc-logs", hours=hours)
+
+
+async def reflex_rules() -> list[dict]:
+    return await rc.safe_list(_REST(), "lab/reflex-rules")
+
+
+async def validation_rules() -> list[dict]:
+    return await rc.safe_list(_REST(), "lab/validation-rules")
+
+
+async def capacity_history(days: int = 30) -> list[dict]:
+    return await rc.safe_list(_REST(), "lab/capacity-history", days=days)
+
+
+async def critical_escalations() -> list[dict]:
+    return await rc.safe_list(_REST(), "lab/critical-escalations")

--- a/fabric/src/service/ot.py
+++ b/fabric/src/service/ot.py
@@ -1,0 +1,26 @@
+from clients import rest_client as rc
+from config import settings
+
+
+def _base() -> str:
+    return f"{settings.db_rest_base_url}/ot"
+
+
+async def rooms() -> list[dict]:
+    return await rc.list_(_base(), "rooms")
+
+
+async def room_status() -> list[dict]:
+    return await rc.list_(_base(), "room-status")
+
+
+async def surgery_schedule() -> list[dict]:
+    return await rc.list_(_base(), "surgery-schedule")
+
+
+async def equipment_usage() -> list[dict]:
+    return await rc.safe_list(_base(), "equipment-usage")
+
+
+async def surgeries() -> list[dict]:
+    return await rc.list_(_base(), "surgeries")

--- a/fabric/src/service/pharmacy.py
+++ b/fabric/src/service/pharmacy.py
@@ -1,0 +1,55 @@
+"""Pharmacy service layer.
+
+All pharmacy data is REST pass-through: Fabric proxies the DB's plain-REST
+/api/pharmacy/* endpoints with no transformation.
+
+pharmacy_orders (MedicationRequest) and pharmacy_inventory (InventoryItem) are
+also FHIR-backed — the change feed picks them up and publishes to Kafka so the
+backend warms Redis. Agents that need live counts read from Redis; these
+pass-through endpoints are for full-list queries that don't fit in Redis keys.
+"""
+
+import logging
+
+from clients import rest_client as rc
+from config import settings
+
+logger = logging.getLogger("pharmacy_service")
+
+_REST = lambda: settings.db_rest_base_url   # http://192.46.212.81:3001/api  # noqa: E731
+
+
+async def orders() -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/orders")
+
+
+async def pending_orders() -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/pending")
+
+
+async def stat_orders() -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/stat")
+
+
+async def inventory() -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/inventory")
+
+
+async def dispensing_log(hours: int = 8) -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/dispensing-log", hours=hours)
+
+
+async def interaction_rules() -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/interactions")
+
+
+async def substitution_rules() -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/substitutions")
+
+
+async def controlled_log(hours: int = 24) -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/controlled-log", hours=hours)
+
+
+async def capacity_history(days: int = 30) -> list[dict]:
+    return await rc.safe_list(_REST(), "pharmacy/capacity", days=days)

--- a/fabric/src/service/staff.py
+++ b/fabric/src/service/staff.py
@@ -1,0 +1,17 @@
+"""Staff + staff-roster reads (HRMS).
+
+No FHIR resource and (today) no plain-REST list endpoint on the DB, so Fabric
+sources these from the DB's keyset sync API — the same approach used for
+lab_result. Rows pass through in the DB's shape (no transform). Inert until the
+DB registers /api/sync/staff and /api/sync/staff_roster.
+"""
+
+from service import initial_sync
+
+
+async def members() -> list[dict]:
+    return await initial_sync.drain("staff")
+
+
+async def roster() -> list[dict]:
+    return await initial_sync.drain("staff_roster")

--- a/fabric/src/service/sync_map.py
+++ b/fabric/src/service/sync_map.py
@@ -1,0 +1,183 @@
+"""Map changed DB data → Kafka (entity, id, data) events.
+
+Two sources feed the same event shape:
+
+  • FHIR change feed (incremental) — the DB's `$changed-resources` Bundle carries
+    standard FHIR R5 resources. `fhir_resources_to_events` turns each into the
+    normalized dict via service.transform (the same transforms the read endpoints
+    use), so `data` matches what Fabric already serves.
+
+  • Plain-REST endpoints (no change feed) — OT / ambulance / appointments have no
+    incremental feed, so the poller fetches the full list and diffs. REST_ENTITIES
+    is the (topic-entity, fetch-coroutine) registry it iterates; rows are already in
+    Fabric's served shape, so they're published as-is.
+
+Entities with no Kafka topic (Patient, Organization, Composition) are skipped.
+`pharmacy_order` has no Fabric endpoint, so it is not published (logged once).
+"""
+
+import logging
+
+from clients import fhir_client as fc
+from service import ambulance as amb_svc
+from service import appointments as appt_svc
+from service import ot as ot_svc
+from service import transform as tx
+from service import lab as lab_svc
+from service import pharmacy as pharmacy_svc
+from service import staff as staff_svc
+from service import ventilator as vent_svc
+from service import financial as fin_svc
+
+logger = logging.getLogger("poller")
+
+# Non-FHIR operational tables that pass through the change feed as raw rows.
+# resourceType in the Bundle entry equals the entity name (set by fabricSync.js).
+_RAW_ENTITIES: frozenset[str] = frozenset({"ventilator", "staff_roster", "staff"})
+
+
+# ─── REST entities (full-list poll + diff) ──────────────────────────────────────
+# topic entity -> coroutine returning list[dict] in Fabric's served shape.
+REST_ENTITIES = [
+    ("ot_room",        ot_svc.rooms),
+    ("ot_room_status", ot_svc.room_status),
+    ("ot_schedule",    ot_svc.surgery_schedule),
+    ("ot_surgery",     ot_svc.surgeries),
+    ("ambulance",      amb_svc.fleet),
+    ("appointment",    appt_svc.list_all),
+    ("doctor_slot",    appt_svc.slots),
+    # billing (DATA_NEEDED) — live via the DB's plain-REST financial API:
+    #   invoice → amount (grand_total) / outstanding (balance) / status
+    #   claim   → payer_type / claim_status (status) / amounts
+    ("invoice",        fin_svc.invoices),
+    ("claim",          fin_svc.claims),
+    # HRMS / ICU (DATA_NEEDED) — sourced by draining the DB keyset sync API. INERT
+    # until the DB registers /api/sync/{staff,staff_roster,ventilator}: the fetch
+    # 404s, the poller logs + skips, nothing is published. No Redis routing on the
+    # backend either (intentional — these feed a separate consumer, not the cache).
+    ("staff",          staff_svc.members),
+    ("staff_roster",   staff_svc.roster),
+    ("ventilator",     vent_svc.units),
+    # lab_sample + lab_analyzer come via the FHIR change feed (Specimen/Device),
+    # not REST polling. pharmacy_order + pharmacy_inventory similarly via
+    # MedicationRequest/InventoryItem. All four are mapped in _map_single below.
+]
+
+
+# ─── FHIR change-feed mapping ───────────────────────────────────────────────────
+def _obs_category(raw: dict) -> str | None:
+    for c in (raw.get("category") or []):
+        for coding in (c.get("coding") or []):
+            if coding.get("code"):
+                return coding["code"]
+    return None
+
+
+def _map_single(rt: str, rid: str, model) -> list[tuple[str, str, dict]]:
+    """Map one non-vital FHIR resource to zero or more (entity, id, data) events."""
+    if rt == "Location" and rid.startswith("bed-"):
+        d = tx.bed(model)
+        return [("bed", d["id"], d)]
+    if rt == "Encounter" and rid.startswith("ipd-"):
+        d = tx.admission(model)
+        out = [("admission", d["id"], d)]
+        if d.get("discharge_ready"):                       # discharge_ready topic: only when true
+            out.append(("discharge_ready", d["id"], d))
+        return out
+    if rt == "Encounter" and rid.startswith("em-"):
+        d = tx.visit(model)
+        return [("visit", d["id"], d)]
+    if rt == "Observation":                                # laboratory (vitals handled separately)
+        d = tx.lab_result(model)
+        return [("lab_result", d["id"], d)]
+    if rt == "ServiceRequest":
+        d = tx.lab_order(model)
+        return [("lab_order", d["id"], d)]
+    if rt == "Task":
+        d = tx.nursing_task(model)
+        return [("task", d["id"], d)]
+    if rt == "Specimen":
+        d = tx.lab_sample(model)
+        return [("lab_sample", d["id"], d)]
+    if rt == "Device":
+        d = tx.lab_analyzer(model)
+        return [("lab_analyzer", d["id"], d)]
+    if rt == "MedicationRequest":
+        d = tx.pharmacy_order(model)
+        return [("pharmacy_order", d["id"], d)]
+    if rt == "InventoryItem":
+        d = tx.pharmacy_inventory(model)
+        return [("pharmacy_inventory", d["id"], d)]
+    return []                                              # Patient / Organization / Composition: no topic
+
+
+def _is_vital_obs(raw: dict, rid: str) -> bool:
+    return raw.get("resourceType") == "Observation" \
+        and not rid.startswith("lab-") \
+        and _obs_category(raw) != "laboratory"
+
+
+def fhir_delete_to_events(request_url: str) -> list[tuple[str, str]]:
+    """Map a FHIR DELETE request.url (e.g. 'Location/bed-101') to (entity, bare_id) pairs.
+
+    Returns empty list for types with no Kafka topic (Patient, Organization,
+    Composition) and for vital Observations (they're grouped readings — a single
+    Observation delete doesn't map cleanly to one vital event).
+    """
+    if "/" not in request_url:
+        return []
+    rt, rid = request_url.split("/", 1)
+    if rt in _RAW_ENTITIES:
+        return [(rt, rid)]
+    if rt == "Location" and rid.startswith("bed-"):
+        return [("bed", rid[len("bed-"):])]
+    if rt == "Encounter" and rid.startswith("ipd-"):
+        return [("admission", rid[len("ipd-"):])]
+    if rt == "Encounter" and rid.startswith("em-"):
+        return [("visit", rid[len("em-"):])]
+    if rt == "Observation" and rid.startswith("lab-"):
+        return [("lab_result", rid[len("lab-"):])]
+    if rt == "ServiceRequest":
+        return [("lab_order", rid)]
+    if rt == "Task":
+        return [("task", rid)]
+    if rt == "Specimen":
+        return [("lab_sample", rid)]
+    if rt == "Device":
+        return [("lab_analyzer", rid)]
+    if rt == "MedicationRequest":
+        return [("pharmacy_order", rid)]
+    if rt == "InventoryItem":
+        return [("pharmacy_inventory", rid)]
+    return []
+
+
+def fhir_resources_to_events(resources: list[dict]) -> list[tuple[str, str, dict]]:
+    """Turn the change feed's FHIR resources into Kafka events. Vital Observations are
+    grouped by reading (the DB emits one Observation per measure) before transforming."""
+    events: list[tuple[str, str, dict]] = []
+    vital_obs: list = []
+    for raw in resources:
+        rt = raw.get("resourceType")
+        rid = raw.get("id") or ""
+
+        # Raw (non-FHIR) entities: resourceType is the entity name. Pass the row
+        # straight through, stripping the resourceType field added by fabricSync.js.
+        if rt in _RAW_ENTITIES:
+            data = {k: v for k, v in raw.items() if k != "resourceType"}
+            events.append((rt, rid, data))
+            continue
+
+        model = fc.parse_resource(raw)
+        if model is None:
+            logger.warning("skip unparseable change-feed %s/%s", rt, rid)
+            continue
+        if _is_vital_obs(raw, rid):
+            vital_obs.append(model)
+            continue
+        events.extend(_map_single(rt, rid, model))
+    for group in tx.group_vitals_by_reading(vital_obs).values():
+        d = tx.vital(group)
+        if d:
+            events.append(("vital", d["id"], d))
+    return events

--- a/fabric/src/service/transform.py
+++ b/fabric/src/service/transform.py
@@ -1,0 +1,550 @@
+"""Standard FHIR R5 → normalized dict.
+
+The DB's FHIR is **standard, extension-free** (per the FHIR spec), so we read the
+data from standard elements. We still reuse the mappers' `to_internal` (which
+already pulls references/values from standard elements) and then fill the few
+fields the mappers sourced from Hospilot extensions (admitted_at, status,
+recorded_at, is_critical, ward, …) from their standard-element equivalents —
+preferring a Hospilot extension when the DB happens to include one (lossless).
+
+Output shapes match exactly what the main backend's db.hasura methods return.
+"""
+
+from fhirgw import terminology as T, extensions as X
+from fhirgw.mappers import location as loc_map, encounter as enc_map, observation as obs_map
+from fhirgw.mappers._common import ref_id, bare_id, coding_code
+
+# reverse of terminology.LOCATION_OPER_STATUS (occupancy code → bed status string)
+_OPER_TO_STATUS = {"U": "Available", "O": "Occupied", "K": "Dirty", "H": "Cleaning"}
+_EXT_ADM_TRANSFER_PENDING = X.EXT_BASE + "admission-transfer-pending"
+# reverse of terminology.INTERPRETATION_MAP (interpretation code → hospilot flag)
+_INTERP_TO_FLAG = {c: flag for flag, (c, _d) in T.INTERPRETATION_MAP.items()}
+
+
+def _dt(value) -> str | None:
+    """ISO-8601 string. fhir.resources parses FHIR dateTime to a Python datetime;
+    use isoformat() (keeps the 'T') rather than str() (which uses a space)."""
+    if value is None:
+        return None
+    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+def _period_start(enc):
+    p = getattr(enc, "actualPeriod", None)
+    return getattr(p, "start", None) if p else None
+
+
+def _reverse_status(fhir_status: str | None) -> str | None:
+    if not fhir_status:
+        return None
+    candidates = T.encounter_status_to_internal(fhir_status)
+    return candidates[0] if candidates else fhir_status
+
+
+# ─── beds ───────────────────────────────────────────────────────────────────────
+def bed(loc, wards_by_id: dict | None = None) -> dict:
+    d = loc_map.to_internal(loc)                       # bed_number(name), is_active, ext fields
+    d["id"] = bare_id(d.get("id"))
+    if not d.get("status"):                            # standard: operationalStatus → status
+        op = getattr(loc, "operationalStatus", None)
+        d["status"] = _OPER_TO_STATUS.get(getattr(op, "code", None)) if op else None
+    if not d.get("ward"):                              # standard: partOf → ward
+        wid = ref_id(getattr(loc, "partOf", None))
+        d["ward"] = (wards_by_id or {}).get(wid, wid)
+    return d
+
+
+def is_icu_bed(bed_dict: dict) -> bool:
+    return "icu" in (bed_dict.get("ward") or "").lower()
+
+
+# ─── admissions / visits ─────────────────────────────────────────────────────────
+def admission(enc) -> dict:
+    d = enc_map.admission_to_internal(enc)            # patient_token, bed_id (standard)
+    d["id"] = bare_id(d.get("id"))
+    d["patient_token"] = bare_id(d.get("patient_token")) or ""
+    d["bed_id"] = bare_id(d.get("bed_id")) if d.get("bed_id") else None
+    if not d.get("admitted_at"):
+        d["admitted_at"] = _dt(_period_start(enc))
+    if not d.get("status"):
+        d["status"] = _reverse_status(enc.status)
+    # Hospilot enrichment — present only if the DB exposes these extensions
+    d["discharge_ready"] = X.get_ext(enc.extension, X.EXT_ADM_DISCHARGE_READY)
+    d["discharge_blocked_reason"] = X.get_ext(enc.extension, X.EXT_ADM_DISCHARGE_BLOCKED_REASON)
+    d["transfer_pending"] = X.get_ext(enc.extension, _EXT_ADM_TRANSFER_PENDING)
+    return d
+
+
+def visit(enc) -> dict:
+    d = enc_map.visit_to_internal(enc)                # patient_token, department_id, chief_complaint
+    d["id"] = bare_id(d.get("id"))
+    d["patient_token"] = bare_id(d.get("patient_token")) or ""
+    d["department_id"] = bare_id(d.get("department_id")) if d.get("department_id") else None
+    if not d.get("arrived_at"):
+        d["arrived_at"] = _dt(_period_start(enc))
+    if not d.get("status"):
+        # EMER source statuses are in-progress/completed/cancelled (not the IMP
+        # "admitted" set), so keep the FHIR status value rather than IMP-reverse.
+        d["status"] = enc.status
+    d["triage_score"] = X.get_ext(enc.extension, X.EXT_VISIT_TRIAGE_SCORE)
+    return d
+
+
+# ─── vitals ───────────────────────────────────────────────────────────────────────
+def _has_critical(o) -> bool:
+    for interp in (getattr(o, "interpretation", None) or []):
+        if coding_code(interp) == T.CRITICAL_INTERP[0]:
+            return True
+    return False
+
+
+def vital(obs_list) -> dict:
+    obs_list = list(obs_list)
+    d = obs_map.vitals_to_internal(obs_list)          # measures + patient_token (standard)
+    if not d:
+        return d
+    d["id"] = bare_id(d.get("id"))
+    d["patient_token"] = bare_id(d.get("patient_token")) or ""
+    if not d.get("recorded_at"):
+        d["recorded_at"] = _dt(getattr(obs_list[0], "effectiveDateTime", None))
+    if d.get("is_critical") is None:
+        d["is_critical"] = any(_has_critical(o) for o in obs_list)
+    return d
+
+
+def group_vitals_by_reading(observations) -> dict[str, list]:
+    """Group vital Observations by their shared reading uuid. The DB emits one
+    Observation per measure with a measure-prefixed id (temp-/hr-/rr-/spo2-/bp-/gcs-
+    + uuid); Hospilot's own mapper uses {uuid}.{loinc}. Stripping the measure prefix
+    (bare_id) then the .loinc suffix yields the reading uuid in both cases."""
+    groups: dict[str, list] = {}
+    for o in observations:
+        rid = bare_id(o.id or "").split(".")[0]
+        groups.setdefault(rid, []).append(o)
+    return groups
+
+
+# ─── labs ───────────────────────────────────────────────────────────────────────
+def _value(o):
+    vq = getattr(o, "valueQuantity", None)
+    if vq is not None and getattr(vq, "value", None) is not None:
+        v = vq.value
+        from decimal import Decimal
+        return float(v) if isinstance(v, Decimal) else v
+    return getattr(o, "valueString", None)
+
+
+def lab_result(o) -> dict:
+    vq = getattr(o, "valueQuantity", None)
+    rr = getattr(o, "referenceRange", None)
+    flag = None
+    for interp in (getattr(o, "interpretation", None) or []):
+        flag = _INTERP_TO_FLAG.get(coding_code(interp), flag)
+    code = getattr(o, "code", None)
+    return {
+        "id": bare_id(o.id),
+        "patient_token": bare_id(ref_id(getattr(o, "subject", None))) or "",
+        "test_code": coding_code(code),
+        "test_name": getattr(code, "text", None) if code else None,
+        "result_value": _value(o),
+        "unit": getattr(vq, "unit", None) if vq else None,
+        "flag": flag,
+        "reference_range": (getattr(rr[0], "text", None) if rr else None),
+        "reported_at": _dt(getattr(o, "effectiveDateTime", None)),
+    }
+
+
+def _first(raw: dict, *keys):
+    """First present, non-None value among `keys` (for tolerant raw-row mapping)."""
+    for k in keys:
+        if raw.get(k) is not None:
+            return raw[k]
+    return None
+
+
+def lab_result_row(raw: dict) -> dict:
+    """Normalize a RAW `hospilot.lab_results` row (from the /sync/lab_result API) into
+    the SAME shape as `lab_result()` above, so polling mode emits the identical
+    `lab_result` contract as the change_api feed.
+
+    The sync API forwards raw DB columns whose exact names aren't part of Fabric's
+    FHIR contract, so we map tolerantly across the likely candidates. If the live
+    `schema.columns` differ, extend the candidate lists here (one place to fix).
+
+    `flag` is the one column confirmed exact (CarerOS's `hospilot.lab_results.flag`,
+    verbatim via `SELECT *`): its value domain is the word vocabulary
+    Critical | High | Low | Normal — already matching `lab_result()`'s
+    `_INTERP_TO_FLAG` output, so no code→word translation is needed here."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "patient_token": str(_first(raw, "patient_token", "patient_id") or ""),
+        "test_code": _first(raw, "test_code", "loinc_code", "code"),
+        "test_name": _first(raw, "test_name", "name", "test"),
+        "result_value": _first(raw, "result_value", "value", "result"),
+        "unit": _first(raw, "unit", "units"),
+        "flag": raw.get("flag"),
+        "reference_range": _first(raw, "reference_range", "ref_range", "normal_range"),
+        "reported_at": _dt(_first(raw, "reported_at", "resulted_at", "updated_at", "created_at")),
+    }
+
+
+# ─── raw-row mappers (Kafka change events carry the row; no re-read needed) ─────
+# Each maps a RAW DB row from a `hospilot.changes.*` event onto the SAME normalized
+# shape the FHIR path produces, so a cached entity never costs an extra HTTP read.
+# Column names are matched tolerantly (the event forwards raw columns), so a schema
+# that names things differently degrades to a re-read rather than to bad data.
+
+
+def _as_bool(v):
+    """Coerce a raw DB boolean-ish value; None stays None (field absent)."""
+    if v is None or isinstance(v, bool):
+        return v
+    if isinstance(v, (int, float)):
+        return bool(v)
+    return str(v).strip().lower() in ("true", "t", "yes", "y", "1")
+
+
+def _as_num(v):
+    if v is None or isinstance(v, (int, float)):
+        return v
+    try:
+        f = float(v)
+        return int(f) if f == int(f) else f
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_list(v):
+    """Bed features arrive as a JSON array, a comma string, or a single value."""
+    if v is None:
+        return []
+    if isinstance(v, list):
+        return [x for x in v if x is not None]
+    if isinstance(v, str):
+        txt = v.strip()
+        if txt.startswith("[") and txt.endswith("]"):
+            import json
+            try:
+                parsed = json.loads(txt)
+                return [x for x in parsed if x is not None] if isinstance(parsed, list) else [txt]
+            except ValueError:
+                pass
+        return [p.strip() for p in txt.split(",") if p.strip()]
+    return [v]
+
+
+def bed_row(raw: dict) -> dict:
+    """Raw `hospilot.beds` row -> the `bed` contract.
+
+    `status` is kept VERBATIM. The FHIR path collapses `reserved`/`vacating` onto
+    `Occupied` (v2-0116 has no distinct code), losing a distinction the consumers
+    actually test for — the raw row preserves it."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "bed_number": _first(raw, "bed_number", "bed_no", "number", "name"),
+        "ward": _first(raw, "ward", "ward_name"),
+        "room_type": _first(raw, "room_type", "roomtype"),
+        "status": _first(raw, "status", "bed_status"),
+        "is_active": _as_bool(_first(raw, "is_active", "active")),
+        "branch_id": _first(raw, "branch_id", "branch"),
+        "ventilation": _first(raw, "ventilation", "ventilator"),
+        "room_sharing": _first(raw, "room_sharing", "sharing"),
+        "proximity": _as_num(_first(raw, "proximity")),
+        "floor": _as_num(_first(raw, "floor")),
+        "wing": _first(raw, "wing"),
+        "natural_light": _as_bool(_first(raw, "natural_light")),
+        "noise_level": _first(raw, "noise_level"),
+        "features": _as_list(_first(raw, "features", "feature")),
+    }
+
+
+def admission_row(raw: dict) -> dict:
+    """Raw `hospilot.ipd_admissions` row -> the `admission` contract.
+
+    `status` is the internal value verbatim (admitted / critical / improving / …),
+    which the FHIR path can only recover from the admission-raw-status extension."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "patient_token": str(_first(raw, "patient_token", "patient_id") or ""),
+        "bed_id": _first(raw, "bed_id", "bed"),
+        "admitted_at": _dt(_first(raw, "admitted_at", "admission_date", "created_at")),
+        "expected_discharge_at": _dt(_first(raw, "expected_discharge_at", "expected_discharge")),
+        "status": _first(raw, "status", "admission_status"),
+        "discharge_ready": _as_bool(_first(raw, "discharge_ready")),
+        "discharge_blocked_reason": _first(raw, "discharge_blocked_reason", "blocked_reason"),
+        "transfer_pending": _as_bool(_first(raw, "transfer_pending")),
+    }
+
+
+def visit_row(raw: dict) -> dict:
+    """Raw `hospilot.visits` row -> the `visit` contract."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "patient_token": str(_first(raw, "patient_token", "patient_id") or ""),
+        "department_id": _first(raw, "department_id", "department", "dept_id"),
+        "arrived_at": _dt(_first(raw, "arrived_at", "arrival_time", "created_at")),
+        "status": _first(raw, "status", "visit_status"),
+        "chief_complaint": _first(raw, "chief_complaint", "complaint", "reason"),
+        "triage_score": _as_num(_first(raw, "triage_score", "triage")),
+    }
+
+
+def lab_order_row(raw: dict) -> dict:
+    """Raw `hospilot.lab_orders` row -> the `lab_order` contract.
+
+    `test_name` lives on the lab_results relation in the FHIR projection, so a bare
+    orders row may not carry it — the completeness guard in the consumer falls back
+    to a re-read when it is missing."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "patient_token": str(_first(raw, "patient_token", "patient_id") or ""),
+        "status": _first(raw, "status", "order_status"),
+        "priority": _first(raw, "priority"),
+        "ordered_at": _dt(_first(raw, "ordered_at", "created_at")),
+        "test_name": _first(raw, "test_name", "test", "name"),
+    }
+
+
+def nursing_task_row(raw: dict) -> dict:
+    """Raw `hospilot.nursing_tasks` row -> the `task` contract.
+
+    The raw table stores a `completed` boolean; the contract carries both that and a
+    FHIR-style `status`, so the status is derived here the same way the projection does."""
+    completed = _as_bool(_first(raw, "completed"))
+    status = _first(raw, "status")
+    if not status:
+        status = "completed" if completed else "requested"
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "admission_id": _first(raw, "admission_id", "admission", "encounter_id"),
+        "task": _first(raw, "task", "description", "task_name"),
+        "due_at": _dt(_first(raw, "due_at", "scheduled_at", "due_date")),
+        "assigned_to": _first(raw, "assigned_to", "owner", "assignee"),
+        "completed": bool(completed),
+        "status": status,
+    }
+
+
+def lab_sample_row(raw: dict) -> dict:
+    """Raw `hospilot.lab_samples` row -> the `lab_sample` contract."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "order_id": _first(raw, "order_id", "lab_order_id"),
+        "patient_token": str(_first(raw, "patient_token", "patient_id") or ""),
+        "barcode": _first(raw, "barcode", "accession_no", "accession"),
+        "status": _first(raw, "status", "sample_status"),
+        "type": _first(raw, "type", "sample_type", "specimen_type"),
+        "collected_at": _dt(_first(raw, "collected_at", "collection_time")),
+        "received_at": _dt(_first(raw, "received_at", "received_time")),
+        "container_type": _first(raw, "container_type", "container", "tube_type"),
+    }
+
+
+def lab_analyzer_row(raw: dict) -> dict:
+    """Raw `hospilot.lab_analyzers` row -> the `lab_analyzer` contract."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "name": _first(raw, "name", "analyzer_name", "device_name"),
+        "model": _first(raw, "model", "model_number", "modelNumber"),
+        "manufacturer": _first(raw, "manufacturer", "make", "vendor"),
+        "status": _first(raw, "status", "analyzer_status"),
+        "location_id": _first(raw, "location_id", "location", "lab_id"),
+    }
+
+
+def pharmacy_order_row(raw: dict) -> dict:
+    """Raw `hospilot.pharmacy_orders` row -> the `pharmacy_order` contract.
+
+    `medication` may be a foreign key to a drug master rather than a name; the
+    completeness guard falls back to a re-read when it resolves empty."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "patient_token": str(_first(raw, "patient_token", "patient_id") or ""),
+        "encounter_id": _first(raw, "encounter_id", "admission_id", "visit_id"),
+        "prescriber_id": _first(raw, "prescriber_id", "prescriber", "doctor_id"),
+        "medication": _first(raw, "medication", "medication_name", "drug_name", "drug"),
+        "status": _first(raw, "status", "order_status"),
+        "intent": _first(raw, "intent"),
+        "priority": _first(raw, "priority"),
+        "dosage": _first(raw, "dosage", "dosage_instruction", "sig"),
+        "prescribed_at": _dt(_first(raw, "prescribed_at", "ordered_at", "created_at")),
+    }
+
+
+def pharmacy_inventory_row(raw: dict) -> dict:
+    """Raw `hospilot.pharmacy_inventory` row -> the `pharmacy_inventory` contract."""
+    return {
+        "id": str(_first(raw, "id") or ""),
+        "name": _first(raw, "name", "item_name", "drug_name"),
+        "code": _first(raw, "code", "item_code", "sku"),
+        "status": _first(raw, "status"),
+        "category": _first(raw, "category", "item_category"),
+        "qty_in_stock": _as_num(_first(raw, "qty_in_stock", "quantity", "stock_qty", "qty")),
+        "unit": _first(raw, "unit", "uom", "units"),
+        "expiry_date": _dt(_first(raw, "expiry_date", "expiry", "expires_at")),
+    }
+
+
+# ─── departments / patients ──────────────────────────────────────────────────────
+def department(org) -> dict:
+    typ = None
+    types = getattr(org, "type", None)
+    if types:
+        typ = getattr(types[0], "text", None)
+    return {"id": bare_id(org.id), "name": org.name, "type": typ}
+
+
+def patient_token(pat) -> str | None:
+    # The DB sets Patient.id = patient_token (= patients.id). identifier[] carries
+    # UHID/ABHA, NOT the token — so the token is the resource id.
+    return bare_id(pat.id)
+
+
+def patient(pat) -> dict:
+    """Full patient dict (demographics) — matches db.hasura.get_patient_names rows."""
+    names = getattr(pat, "name", None) or []
+    name = names[0] if names else None
+    given = " ".join(getattr(name, "given", None) or []) if name else None
+    family = getattr(name, "family", None) if name else None
+    idents = getattr(pat, "identifier", None) or []
+    uhid = None
+    for i in idents:
+        if "uhid" in (getattr(i, "system", "") or "").lower():
+            uhid = getattr(i, "value", None)
+            break
+    if uhid is None and idents:
+        uhid = getattr(idents[0], "value", None)
+    tel = getattr(pat, "telecom", None) or []
+    return {
+        "id": bare_id(pat.id),
+        "patient_token": bare_id(pat.id),
+        "first_name": given,
+        "last_name": family,
+        "uhid": uhid,
+        "gender": getattr(pat, "gender", None),
+        "dob": _dt(getattr(pat, "birthDate", None)),
+        "phone": getattr(tel[0], "value", None) if tel else None,
+    }
+
+
+# ─── tasks / lab orders ──────────────────────────────────────────────────────────
+def nursing_task(t) -> dict:
+    ep = getattr(t, "executionPeriod", None)
+    enc_ref = ref_id(getattr(t, "encounter", None)) or ref_id(getattr(t, "for_fhir", None))
+    return {
+        "id": bare_id(t.id),
+        "admission_id": bare_id(enc_ref),
+        "task": getattr(t, "description", None),
+        "due_at": _dt(getattr(ep, "start", None) if ep else None),
+        "assigned_to": ref_id(getattr(t, "owner", None)),
+        "completed": getattr(t, "status", None) == "completed",
+        "status": getattr(t, "status", None),
+    }
+
+
+def lab_order(sr) -> dict:
+    code = getattr(sr, "code", None)               # R5 CodeableReference
+    concept = getattr(code, "concept", None) if code else None
+    return {
+        "id": bare_id(sr.id),
+        "patient_token": bare_id(ref_id(getattr(sr, "subject", None))) or "",
+        "status": getattr(sr, "status", None),
+        "priority": getattr(sr, "priority", None),
+        "ordered_at": _dt(getattr(sr, "authoredOn", None)),
+        "test_name": getattr(concept, "text", None) if concept else None,
+    }
+
+
+# ─── lab samples / analyzers (Redis-backed) ─────────────────────────────────────
+def lab_sample(specimen) -> dict:
+    idents = getattr(specimen, "identifier", None) or []
+    barcode = getattr(idents[0], "value", None) if idents else None
+    requests = getattr(specimen, "request", None) or []
+    order_id = bare_id(ref_id(requests[0])) if requests else None
+    coll = getattr(specimen, "collection", None)
+    collected_at = _dt(getattr(coll, "collectedDateTime", None)) if coll else None
+    spec_type = getattr(specimen, "type", None)
+    containers = getattr(specimen, "container", None) or []
+    container_type = None
+    if containers:
+        ct = getattr(containers[0], "type", None)
+        container_type = getattr(ct, "text", None) if ct else None
+    return {
+        "id": bare_id(specimen.id),
+        "order_id": order_id,
+        "patient_token": bare_id(ref_id(getattr(specimen, "subject", None))) or "",
+        "barcode": barcode,
+        "status": getattr(specimen, "status", None),
+        "type": getattr(spec_type, "text", None) if spec_type else None,
+        "collected_at": collected_at,
+        "received_at": _dt(getattr(specimen, "receivedTime", None)),
+        "container_type": container_type,
+    }
+
+
+def lab_analyzer(device) -> dict:
+    names = getattr(device, "deviceName", None) or []
+    name = getattr(names[0], "name", None) if names else None
+    # R5 Device.manufacturer is a string, not a reference
+    manufacturer = getattr(device, "manufacturer", None)
+    if not isinstance(manufacturer, str):
+        manufacturer = getattr(manufacturer, "display", None) if manufacturer else None
+    loc = getattr(device, "location", None)
+    return {
+        "id": bare_id(device.id),
+        "name": name,
+        "model": getattr(device, "modelNumber", None),
+        "manufacturer": manufacturer,
+        "status": getattr(device, "status", None),
+        "location_id": bare_id(ref_id(loc)) if loc else None,
+    }
+
+
+# ─── pharmacy orders / inventory (Redis-backed) ──────────────────────────────────
+def pharmacy_order(med_req) -> dict:
+    med = getattr(med_req, "medication", None)          # R5 CodeableReference
+    concept = getattr(med, "concept", None) if med else None
+    med_display = getattr(concept, "text", None) if concept else None
+    if not med_display:
+        med_display = getattr(med, "display", None) if med else None
+    dosage_list = getattr(med_req, "dosageInstruction", None) or []
+    dosage = getattr(dosage_list[0], "text", None) if dosage_list else None
+    return {
+        "id": bare_id(med_req.id),
+        "patient_token": bare_id(ref_id(getattr(med_req, "subject", None))) or "",
+        "encounter_id": bare_id(ref_id(getattr(med_req, "encounter", None))),
+        "prescriber_id": bare_id(ref_id(getattr(med_req, "requester", None))),
+        "medication": med_display,
+        "status": getattr(med_req, "status", None),
+        "intent": getattr(med_req, "intent", None),
+        "priority": getattr(med_req, "priority", None),
+        "dosage": dosage,
+        "prescribed_at": _dt(getattr(med_req, "authoredOn", None)),
+    }
+
+
+def pharmacy_inventory(inv_item) -> dict:
+    names = getattr(inv_item, "name", None) or []
+    name = getattr(names[0], "name", None) if names else None
+    codes = getattr(inv_item, "code", None) or []
+    code_concept = getattr(codes[0], "concept", None) if codes else None
+    code_text = getattr(code_concept, "text", None) if code_concept else None
+    categories = getattr(inv_item, "category", None) or []
+    category = getattr(categories[0], "text", None) if categories else None
+    net = getattr(inv_item, "netContent", None)
+    instance = getattr(inv_item, "instance", None)
+    expiry = None
+    if instance:
+        if isinstance(instance, list):
+            instance = instance[0] if instance else None
+        expiry = _dt(getattr(instance, "expiry", None)) if instance else None
+    return {
+        "id": bare_id(inv_item.id),
+        "name": name,
+        "code": code_text,
+        "status": getattr(inv_item, "status", None),
+        "category": category,
+        "qty_in_stock": getattr(net, "value", None) if net else None,
+        "unit": getattr(net, "unit", None) if net else None,
+        "expiry_date": expiry,
+    }

--- a/fabric/src/service/ventilator.py
+++ b/fabric/src/service/ventilator.py
@@ -1,0 +1,12 @@
+"""Ventilator inventory reads (ICU).
+
+No FHIR resource and no plain-REST list endpoint upstream, so Fabric sources this
+from the DB's keyset sync API (like lab_result). Rows pass through in the DB's
+shape. Inert until the DB registers /api/sync/ventilator.
+"""
+
+from service import initial_sync
+
+
+async def units() -> list[dict]:
+    return await initial_sync.drain("ventilator")

--- a/fabric/src/service/writes.py
+++ b/fabric/src/service/writes.py
@@ -1,0 +1,177 @@
+"""Writes — queues normalized changes from the main app for the DB to pull.
+
+Instead of PATCHing the DB directly, each write adds a PendingChange to the
+in-memory store. The DB calls GET /fhir/Bundle/$pending-changes to receive all
+queued changes as a FHIR R5 transaction Bundle and acknowledges receipt via
+POST /fhir/Bundle/$pending-changes/$acknowledge, after which the queue is cleared.
+"""
+
+from fhirgw import terminology as T
+from service.change_store import PendingChange, get_change_store, new_change_id, now_iso
+
+# Logical Kafka entity each change_type acknowledges against (drives the ack event's
+# `entity`). Mirrors the entities the read-direction feed publishes, so the backend can
+# correlate an ack to the same record it optimistically updated.
+CHANGE_TYPE_ENTITY = {
+    "bed_status": "bed",
+    "triage_score": "visit",
+    "discharge_ready": "admission",
+    "transfer_pending": "admission",
+    "critical_vital": "vital",
+    "ai_discharge_note": "discharge_summary",
+    "slot_book": "doctor_slot",
+    "appointment_create": "appointment",
+    "surgery_reschedule": "ot_surgery",
+}
+
+# Whether each change_type must be routed through the DB-side approval workflow before it
+# is written to the HIS (surfaced as `approvalNeeded` on each snapshot Bundle entry — see
+# the Diff_Engine ApprovalWrite2HIS spec). bed_status is overridden per status value in
+# update_bed_status, since one change_type covers both reservation (approval) and cleaning
+# (no approval). Actions absent from the spec table default to False.
+CHANGE_TYPE_APPROVAL = {
+    "bed_status": False,        # overridden per status in update_bed_status
+    "triage_score": False,
+    "discharge_ready": True,
+    "transfer_pending": True,
+    "critical_vital": False,
+    "ai_discharge_note": True,
+    "slot_book": False,
+    "appointment_create": False,
+    "surgery_reschedule": True,   # surgery moves are high-impact -> hospital approves in fabric_approval_queue
+}
+
+# Bed statuses that require approval (bed reservation); cleaning/occupancy/etc. do not. The
+# raw status is read here because terminology.operational_status is lossy (reserved and
+# occupied collapse to the same code), so the distinction is gone by bundle-build time.
+_BED_STATUS_NEEDS_APPROVAL = {"reserved"}
+
+
+def _pref(prefix: str, rid: str) -> str:
+    rid = str(rid)
+    return rid if rid.startswith(prefix) else prefix + rid
+
+
+async def update_bed_status(bed_id: str, status: str):
+    op = T.operational_status(status)
+    if not op:
+        raise ValueError(f"Unknown bed status: {status}")
+    await get_change_store().add(PendingChange(
+        change_type="bed_status",
+        resource_type="Location",
+        resource_id=_pref("bed-", bed_id),
+        http_method="PATCH",
+        payload={"code": op[0], "display": op[1]},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["bed_status"],
+        record_id=str(bed_id),
+        approval_needed=status.lower() in _BED_STATUS_NEEDS_APPROVAL,
+    ))
+    return {"ok": True}
+
+
+async def set_triage_score(visit_id: str, score: int):
+    await get_change_store().add(PendingChange(
+        change_type="triage_score",
+        resource_type="Encounter",
+        resource_id=_pref("em-", visit_id),
+        http_method="PATCH",
+        payload={"score": score},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["triage_score"],
+        record_id=str(visit_id),
+        approval_needed=CHANGE_TYPE_APPROVAL["triage_score"],
+    ))
+    return {"ok": True}
+
+
+async def bulk_set_triage_scores(items: list[dict]):
+    return [await set_triage_score(i["visit_id"], i["score"]) for i in items]
+
+
+async def update_discharge_ready(admission_id: str, ready: bool, blocked_reason: str | None = None):
+    await get_change_store().add(PendingChange(
+        change_type="discharge_ready",
+        resource_type="Encounter",
+        resource_id=_pref("ipd-", admission_id),
+        http_method="PATCH",
+        payload={"ready": ready, "blocked_reason": blocked_reason},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["discharge_ready"],
+        record_id=str(admission_id),
+        approval_needed=CHANGE_TYPE_APPROVAL["discharge_ready"],
+    ))
+    return {"ok": True}
+
+
+async def set_admissions_transfer_pending(ids: list[str]):
+    for aid in ids:
+        await get_change_store().add(PendingChange(
+            change_type="transfer_pending",
+            resource_type="Encounter",
+            resource_id=_pref("ipd-", aid),
+            http_method="PATCH",
+            payload={},
+            timestamp=now_iso(),
+            change_id=new_change_id(),
+            entity=CHANGE_TYPE_ENTITY["transfer_pending"],
+            record_id=str(aid),
+            approval_needed=CHANGE_TYPE_APPROVAL["transfer_pending"],
+        ))
+    return [{"ok": True}] * len(ids)
+
+
+async def flag_critical_vital(vital_id: str):
+    await get_change_store().add(PendingChange(
+        change_type="critical_vital",
+        resource_type="Observation",
+        resource_id=None,  # resolved at bundle-build time by trying each measure prefix
+        http_method="PATCH",
+        payload={"vital_id": vital_id},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["critical_vital"],
+        record_id=str(vital_id),
+        approval_needed=CHANGE_TYPE_APPROVAL["critical_vital"],
+    ))
+    return {"ok": True, "id": vital_id}
+
+
+async def reschedule_surgery(surgery_id: str, fields: dict):
+    """Queue an executable reschedule of a surgery. The PATCH targets ot_surgeries
+    directly (url = ot_surgeries/{id}), and the raw update rides in the bundle entry's
+    extension so the DB-side applier can update the row generically. approval_needed=True
+    routes it through fabric_approval_queue for the hospital to sign off before applying."""
+    await get_change_store().add(PendingChange(
+        change_type="surgery_reschedule",
+        resource_type="ot_surgeries",          # -> transaction url ot_surgeries/{id} -> change_queue.table_name
+        resource_id=str(surgery_id),
+        http_method="PATCH",
+        payload={"table_name": "ot_surgeries", "operation": "update",
+                 "record_id": str(surgery_id), "fields": fields},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["surgery_reschedule"],
+        record_id=str(surgery_id),
+        approval_needed=CHANGE_TYPE_APPROVAL["surgery_reschedule"],
+    ))
+    return {"ok": True}
+
+
+async def set_ai_discharge_note(admission_id: str, note: str):
+    await get_change_store().add(PendingChange(
+        change_type="ai_discharge_note",
+        resource_type="Composition",
+        resource_id=None,  # resolved at bundle-build time via Composition search
+        http_method="PATCH",
+        payload={"admission_id": _pref("ipd-", admission_id), "note": note},
+        timestamp=now_iso(),
+        change_id=new_change_id(),
+        entity=CHANGE_TYPE_ENTITY["ai_discharge_note"],
+        record_id=str(admission_id),
+        approval_needed=CHANGE_TYPE_APPROVAL["ai_discharge_note"],
+    ))
+    return {"ok": True}

--- a/fabric/tests/conftest.py
+++ b/fabric/tests/conftest.py
@@ -1,0 +1,22 @@
+"""
+Test bootstrap. Fabric runs with `src/` as the import root; pyproject also sets
+pythonpath=["src"]. Settings all have safe defaults, so no real upstreams needed.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("EHR_FHIR_BASE_URL", "http://localhost:3001/fhir")
+os.environ.setdefault("FINANCIAL_API_BASE_URL", "http://localhost:3001/api/financial")
+os.environ.setdefault("FABRIC_API_KEY", "")     # Fabric auth disabled in tests
+
+# Pin the ingest mode and disable Kafka. Without these, a developer's local
+# `fabric/.env` (which may set INTEGRATION_MODE=kafka) leaks into the suite: the
+# $pending-changes pull returns 409 in kafka mode, and the mode-default assertion
+# flips. Tests that exercise kafka mode set it explicitly via monkeypatch.
+os.environ.setdefault("INTEGRATION_MODE", "change_api")
+os.environ.setdefault("KAFKA_BOOTSTRAP_SERVERS", "")

--- a/fabric/tests/test_all.sh
+++ b/fabric/tests/test_all.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Live endpoint test for Hospilot-Fabric @ http://192.46.212.81:8001
+# Reads are safe. Writes are skipped by default — pass --write to enable.
+# Usage:
+#   bash scripts/test_all.sh
+#   bash scripts/test_all.sh --write
+#   FABRIC_API_KEY=<key> bash scripts/test_all.sh
+
+set -euo pipefail
+
+BASE="${FABRIC_BASE_URL:-http://192.46.212.81:8001}"
+KEY="${FABRIC_API_KEY:-}"
+WRITE=false
+[[ "${1:-}" == "--write" ]] && WRITE=true
+
+AUTH_HDR=()
+[[ -n "$KEY" ]] && AUTH_HDR=(-H "Authorization: Bearer $KEY")
+
+PASS=0; FAIL=0; SKIP=0
+
+hit() {
+  local method="$1" path="$2"
+  local code
+  code=$(curl -s -o /tmp/fab_resp -w "%{http_code}" "${AUTH_HDR[@]}" -X "$method" "${BASE}${path}")
+  if [[ "$code" -lt 400 ]]; then
+    echo "  PASS  $method $path  ($code)"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  $method $path  ($code) $(cat /tmp/fab_resp | head -c 120)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+hit_post() {
+  local path="$1" body="${2:-}"
+  local code
+  code=$(curl -s -o /tmp/fab_resp -w "%{http_code}" "${AUTH_HDR[@]}" -X POST -H "Content-Type: application/json" -d "$body" "${BASE}${path}")
+  if [[ "$code" -lt 400 ]]; then
+    echo "  PASS  POST $path  ($code)"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  POST $path  ($code) $(cat /tmp/fab_resp | head -c 120)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+skip() {
+  echo "  SKIP  $*  (writes disabled)"
+  SKIP=$((SKIP+1))
+}
+
+echo ""
+echo "▶ Fabric endpoint test  base=$BASE  auth=${KEY:+on}${KEY:-off}  writes=$WRITE"
+echo ""
+
+# ── health ──────────────────────────────────────────────────────────────────
+hit GET /health
+
+# ── beds ────────────────────────────────────────────────────────────────────
+hit GET /beds
+hit GET /beds/available-icu
+hit GET /beds/dirty
+hit GET /beds/dirty-icu
+hit GET /beds/postop
+hit GET /beds/summary
+
+# Prime bed_id from /beds
+BED_ID=$(curl -s "${AUTH_HDR[@]}" "${BASE}/beds" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+[[ -n "$BED_ID" ]] && hit GET "/beds/$BED_ID"
+
+# ── admissions ──────────────────────────────────────────────────────────────
+hit GET /admissions/icu
+hit GET /admissions/non-icu
+hit GET /admissions/with-wards
+hit GET /admissions/discharge-eligible
+hit GET /admissions/discharge-ready
+hit GET /admissions/discharge-ready-count
+hit GET "/admissions/discharge-horizon?hours=24"
+
+# Prime adm_id + patient_token from /admissions/icu
+ICU=$(curl -s "${AUTH_HDR[@]}" "${BASE}/admissions/icu" 2>/dev/null || echo "[]")
+ADM_ID=$(echo "$ICU" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+PATIENT=$(echo "$ICU" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('patient_token','') if d else '')" 2>/dev/null || true)
+
+[[ -n "$ADM_ID" ]] && hit GET "/admissions/$ADM_ID"
+
+# ── vitals ──────────────────────────────────────────────────────────────────
+hit GET /vitals/critical
+[[ -n "$PATIENT" ]] && hit GET "/vitals/latest?patient=$PATIENT" || { echo "  SKIP  GET /vitals/latest  (no patient token)"; SKIP=$((SKIP+1)); }
+
+# ── ER / visits ─────────────────────────────────────────────────────────────
+hit GET /visits/er
+hit GET /visits/untriaged
+hit GET /er/pressure
+
+# Prime visit_id from /visits/er
+VISITS=$(curl -s "${AUTH_HDR[@]}" "${BASE}/visits/er" 2>/dev/null || echo "[]")
+VISIT_ID=$(echo "$VISITS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+[[ -z "$PATIENT" ]] && PATIENT=$(echo "$VISITS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('patient_token','') if d else '')" 2>/dev/null || true)
+
+# ── tasks ────────────────────────────────────────────────────────────────────
+hit GET /tasks/incomplete
+hit GET /tasks/overdue
+[[ -n "$ADM_ID" ]] && { hit GET "/tasks?admission=$ADM_ID"; hit GET "/tasks/completed-count?admission=$ADM_ID"; } \
+  || { echo "  SKIP  GET /tasks?admission=  (no adm_id)"; echo "  SKIP  GET /tasks/completed-count  (no adm_id)"; SKIP=$((SKIP+2)); }
+
+# ── labs ─────────────────────────────────────────────────────────────────────
+hit GET /labs/orders/pending
+[[ -n "$PATIENT" ]] && hit GET "/labs/results?patient=$PATIENT" || { echo "  SKIP  GET /labs/results  (no patient token)"; SKIP=$((SKIP+1)); }
+
+# ── departments / patients ────────────────────────────────────────────────────
+hit GET /departments
+hit GET /patients/tokens
+[[ -n "$PATIENT" ]] && hit GET "/patients?ids=$PATIENT"
+
+# ── financial reads ───────────────────────────────────────────────────────────
+hit GET /financial/invoices
+hit GET "/financial/invoices?payment_status=Unpaid,Partial"
+[[ -n "$PATIENT" ]] && hit GET "/financial/invoices?patient=$PATIENT"
+
+hit GET /financial/claims
+hit GET /financial/payments
+hit GET /financial/refunds
+hit GET /financial/contracts
+hit GET /financial/collections/$(date +%Y-%m-%d)
+hit GET /financial/reconciliation/$(date +%Y-%m-%d)
+
+# Prime financial sub-resource IDs
+CLAIM_ID=$(curl -s "${AUTH_HDR[@]}" "${BASE}/financial/claims" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+PAYMENT_ID=$(curl -s "${AUTH_HDR[@]}" "${BASE}/financial/payments" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+CONTRACT_ID=$(curl -s "${AUTH_HDR[@]}" "${BASE}/financial/contracts" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+INVOICE_ID=$(curl -s "${AUTH_HDR[@]}" "${BASE}/financial/invoices" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+
+[[ -n "$CLAIM_ID"   ]] && { hit GET "/financial/claims/$CLAIM_ID/line-items"; hit GET "/financial/claims/$CLAIM_ID/history"; hit GET "/financial/claims/$CLAIM_ID/queries"; }
+[[ -n "$PAYMENT_ID" ]] && hit GET "/financial/payments/$PAYMENT_ID/entries"
+[[ -n "$CONTRACT_ID" ]] && hit GET "/financial/contracts/$CONTRACT_ID/rates"
+[[ -n "$INVOICE_ID" ]] && hit GET "/financial/invoices/$INVOICE_ID/line-items"
+
+# ── writes (opt-in) ───────────────────────────────────────────────────────────
+if $WRITE; then
+  echo ""
+  echo "  ! writes enabled — these flow through to the DB"
+  [[ -n "$VISIT_ID" ]]  && hit_post "/visits/$VISIT_ID/triage"          '{"score":3}'          || skip "POST /visits/{id}/triage (no visit_id)"
+  [[ -n "$ADM_ID"   ]]  && hit_post "/admissions/$ADM_ID/discharge-ready" '{"ready":false}'    || skip "POST /admissions/{id}/discharge-ready (no adm_id)"
+  [[ -n "$BED_ID"   ]]  && hit_post "/beds/$BED_ID/status"              '{"status":"available"}' || skip "POST /beds/{id}/status (no bed_id)"
+else
+  skip "POST /visits/{id}/triage            (use --write)"
+  skip "POST /admissions/{id}/discharge-ready (use --write)"
+  skip "POST /admissions/transfer-pending   (use --write)"
+  skip "POST /vitals/{id}/critical          (use --write)"
+  skip "POST /beds/{id}/status              (use --write)"
+  skip "POST /discharge-summaries/{id}/ai-note (use --write)"
+fi
+
+echo ""
+echo "  $PASS passed · $FAIL failed · $SKIP skipped"
+echo ""
+[[ "$FAIL" -eq 0 ]]

--- a/fabric/tests/test_diff_poller.py
+++ b/fabric/tests/test_diff_poller.py
@@ -1,0 +1,224 @@
+"""Polling-mode diff poller tests — pure, no live DB / Kafka.
+
+Drives the async diff logic with asyncio.run (no pytest-asyncio, matching the rest of
+the suite) and captures publishes by monkeypatching kafka_publisher.publish.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from ingest import diff_poller as dp
+from ingest import kafka_publisher
+from service import transform as tx
+
+_REAL_PUBLISH = kafka_publisher.publish      # captured before the autouse fixture patches it
+
+
+# ─── publish capture ──────────────────────────────────────────────────────────────
+PUBLISHED: list[dict] = []
+
+
+@pytest.fixture(autouse=True)
+def capture(monkeypatch):
+    PUBLISHED.clear()
+    dp.reset_cache()
+
+    async def _pub(entity, record_id, data, operation="upsert", changed=None):
+        PUBLISHED.append({"entity": entity, "id": record_id, "operation": operation,
+                          "data": data, "changed": changed})
+
+    monkeypatch.setattr(kafka_publisher, "publish", _pub)
+    yield
+    PUBLISHED.clear()
+    dp.reset_cache()
+
+
+def _run_entity_once(entity, rows):
+    """Run one poll cycle for a DiffEntity whose fetch returns `rows`."""
+    e = dp.DiffEntity(entity.entity, lambda: _async(rows), entity.mutable_cols, entity.id_key)
+    asyncio.run(dp._poll_entity(e))
+
+
+async def _async(value):
+    return value
+
+
+BED = next(e for e in dp.CLINICAL_ENTITIES if e.entity == "bed")
+ADMISSION = next(e for e in dp.CLINICAL_ENTITIES if e.entity == "admission")
+
+
+# ─── diff algorithm ────────────────────────────────────────────────────────────────
+def test_new_record_publishes_full_upsert():
+    row = {"id": "B1", "status": "Available", "is_active": True, "ward": "ICU"}
+    _run_entity_once(BED, [row])
+    assert len(PUBLISHED) == 1
+    ev = PUBLISHED[0]
+    assert ev["entity"] == "bed" and ev["id"] == "B1"
+    assert ev["operation"] == "upsert" and ev["changed"] is None
+    assert ev["data"] == row                      # FULL row on first sight
+
+
+def test_changed_column_publishes_patch_with_only_that_column():
+    row = {"id": "B1", "status": "Available", "is_active": True, "ward": "ICU"}
+    _run_entity_once(BED, [row])                   # seed
+    PUBLISHED.clear()
+    _run_entity_once(BED, [{**row, "status": "Occupied"}])
+    assert len(PUBLISHED) == 1
+    ev = PUBLISHED[0]
+    assert ev["operation"] == "patch"
+    assert ev["changed"] == ["status"]
+    assert ev["data"] == {"status": "Occupied"}    # ONLY the changed column, not the full row
+
+
+def test_unchanged_record_publishes_nothing():
+    row = {"id": "B1", "status": "Available", "is_active": True, "ward": "ICU"}
+    _run_entity_once(BED, [row])
+    PUBLISHED.clear()
+    _run_entity_once(BED, [dict(row)])             # same tracked values
+    assert PUBLISHED == []
+
+
+def test_untracked_column_change_is_ignored():
+    row = {"id": "B1", "status": "Available", "is_active": True, "ward": "ICU"}
+    _run_entity_once(BED, [row])
+    PUBLISHED.clear()
+    _run_entity_once(BED, [{**row, "ward": "WARD-B"}])   # ward is not a tracked mutable col
+    assert PUBLISHED == []
+
+
+# ─── at-least-once: failed publish must not advance the cache ──────────────────────
+def test_failed_publish_replays_next_cycle(monkeypatch):
+    calls = {"n": 0}
+
+    async def _flaky(entity, record_id, data, operation="upsert", changed=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("kafka down")
+        PUBLISHED.append({"entity": entity, "id": record_id, "operation": operation,
+                          "data": data, "changed": changed})
+
+    monkeypatch.setattr(kafka_publisher, "publish", _flaky)
+    row = {"id": "B1", "status": "Available", "is_active": True}
+    _run_entity_once(BED, [row])                   # publish raises → cache NOT updated
+    assert PUBLISHED == []
+    _run_entity_once(BED, [row])                   # re-detected as new → republished
+    assert len(PUBLISHED) == 1 and PUBLISHED[0]["operation"] == "upsert"
+
+
+# ─── bed Available↔Dirty transition is a status patch, not delete+new ──────────────
+def test_bed_suspended_transition_is_a_patch():
+    active = {"id": "B1", "status": "Available", "is_active": True}
+    _run_entity_once(BED, [active])                # seen as active
+    PUBLISHED.clear()
+    # next cycle: the same bed now suspended/dirty (union of beds()+dirty_beds())
+    dirty = {"id": "B1", "status": "Dirty", "is_active": False}
+    _run_entity_once(BED, [dirty])
+    assert len(PUBLISHED) == 1
+    ev = PUBLISHED[0]
+    assert ev["operation"] == "patch"
+    assert set(ev["changed"]) == {"status", "is_active"}
+    assert ev["data"] == {"status": "Dirty", "is_active": False}
+
+
+# ─── admission discharge_ready companion topic ─────────────────────────────────────
+def test_admission_discharge_ready_fans_out_companion_topic():
+    adm = {"id": "a7", "status": "in-progress", "discharge_ready": True,
+           "discharge_blocked_reason": None, "transfer_pending": False, "bed_id": "B1"}
+    _run_entity_once(ADMISSION, [adm])
+    topics = {(e["entity"], e["operation"]) for e in PUBLISHED}
+    assert ("admission", "upsert") in topics
+    assert ("discharge_ready", "upsert") in topics       # fan-out mirrors change_api
+
+
+# ─── lab_result keyset pagination ──────────────────────────────────────────────────
+def test_lab_result_pagination_walks_all_pages(monkeypatch):
+    pages = {
+        None: {"sync_id": "s1", "rows": [{"id": "L1", "result_value": 1}],
+               "pagination": {"has_more": True, "next_cursor": "C1"}},
+        "C1": {"sync_id": "s1", "rows": [{"id": "L2", "result_value": 2}],
+               "pagination": {"has_more": False, "next_cursor": None}},
+    }
+
+    async def _page(table, *, limit=None, cursor=None, sync_id=None):
+        assert table == "lab_result"
+        return pages[cursor]
+
+    monkeypatch.setattr(dp.initial_sync, "page", _page)
+    rows = asyncio.run(dp._fetch_lab_results())
+    ids = {r["id"] for r in rows}
+    assert ids == {"L1", "L2"}                            # both pages walked, loop terminated
+
+
+def test_lab_result_pagination_stops_on_repeated_cursor(monkeypatch):
+    async def _page(table, *, limit=None, cursor=None, sync_id=None):
+        # pathological server: always says has_more with the same cursor
+        return {"rows": [{"id": "L1"}], "pagination": {"has_more": True, "next_cursor": "STUCK"}}
+
+    monkeypatch.setattr(dp.initial_sync, "page", _page)
+    rows = asyncio.run(dp._fetch_lab_results())           # must not hang
+    assert len(rows) >= 1
+
+
+# ─── config flag + validation ──────────────────────────────────────────────────────
+def test_integration_mode_default_and_property(monkeypatch):
+    from config import Settings
+    # Assert the built-in DEFAULT, so an exported INTEGRATION_MODE (or a developer's
+    # fabric/.env) cannot flip the result.
+    monkeypatch.delenv("INTEGRATION_MODE", raising=False)
+    s = Settings(_env_file=None)
+    assert s.integration_mode == "change_api"
+    assert s.polling_mode is False
+    assert Settings(integration_mode="POLLING").polling_mode is True
+
+
+def test_integration_mode_rejects_unknown():
+    from config import Settings
+    with pytest.raises(Exception):
+        Settings(integration_mode="bogus")
+
+
+def test_poll_intervals_map_keys():
+    from config import settings
+    assert set(settings.poll_intervals_ms) == {
+        "bed", "admission", "visit", "lab_order", "task", "lab_result"}
+
+
+# ─── publisher payload parity (change_api shape unchanged) ─────────────────────────
+def test_publish_payload_omits_changed_unless_given():
+    captured = {}
+
+    class _Prod:
+        async def send_and_wait(self, topic, value, key):
+            captured["topic"] = topic
+            captured["payload"] = json.loads(value.decode())
+
+    kafka_publisher._producer = _Prod()
+    try:
+        asyncio.run(_REAL_PUBLISH("bed", "B1", {"status": "Available"}))
+        assert "changed" not in captured["payload"]      # upsert: byte-parity with today
+        asyncio.run(_REAL_PUBLISH(
+            "bed", "B1", {"status": "Occupied"}, operation="patch", changed=["status"]))
+        assert captured["payload"]["changed"] == ["status"]
+        assert captured["payload"]["operation"] == "patch"
+    finally:
+        kafka_publisher._producer = None
+
+
+# ─── lab_result_row normalizer ─────────────────────────────────────────────────────
+def test_lab_result_row_maps_candidate_columns():
+    raw = {"id": "L1", "patient_id": "pt-9", "loinc_code": "718-7", "name": "Hemoglobin",
+           "value": 9.1, "units": "g/dL", "flag": "Low", "ref_range": "12-16",
+           "resulted_at": "2026-06-12T10:00:00"}
+    out = tx.lab_result_row(raw)
+    assert out["id"] == "L1" and out["patient_token"] == "pt-9"
+    assert out["test_code"] == "718-7" and out["test_name"] == "Hemoglobin"
+    assert out["result_value"] == 9.1 and out["unit"] == "g/dL"
+    # `flag` is read from the confirmed `flag` column only, and carries the word
+    # vocabulary (Critical | High | Low | Normal) that lab_result() also emits.
+    assert out["flag"] == "Low" and out["reference_range"] == "12-16"
+    assert out["reported_at"] == "2026-06-12T10:00:00"
+    # shape parity: same keys the change_api lab_result() emits
+    assert set(out) == {"id", "patient_token", "test_code", "test_name",
+                        "result_value", "unit", "flag", "reference_range", "reported_at"}

--- a/fabric/tests/test_endpoints.py
+++ b/fabric/tests/test_endpoints.py
@@ -1,0 +1,209 @@
+"""
+Endpoint tests — mock the outbound clients (DB FHIR + financial REST) and verify
+the route → service → transform path end-to-end, plus a write PATCH.
+"""
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fhir.resources.location import Location
+
+from clients import fhir_client, rest_client
+from fhirgw.mappers import encounter as enc_map, observation as obs_map
+from api.normalized import router
+
+
+def _strip(model):
+    d = json.loads(model.model_dump_json(exclude_none=True, by_alias=True))
+
+    def s(x):
+        if isinstance(x, dict):
+            x.pop("extension", None)
+            return {k: s(v) for k, v in x.items()}
+        if isinstance(x, list):
+            return [s(i) for i in x]
+        return x
+
+    return type(model).model_validate(s(d))
+
+
+def _bed(bid, name, oper, ward_ref="Location/W1"):
+    return Location(
+        id=bid, status="active", name=name, mode="instance",
+        form={"coding": [{"system": "http://terminology.hl7.org/CodeSystem/location-physical-type", "code": "bd"}]},
+        operationalStatus={"system": "http://terminology.hl7.org/CodeSystem/v2-0116", "code": oper},
+        partOf={"reference": ward_ref},
+    )
+
+
+def _ward(wid, name):
+    return Location(
+        id=wid, status="active", name=name, mode="instance",
+        form={"coding": [{"system": "http://terminology.hl7.org/CodeSystem/location-physical-type", "code": "wa"}]},
+    )
+
+
+ADM = _strip(enc_map.admission_to_fhir({
+    "id": "adm-1", "patient_token": "pt-1", "bed_id": "B1",
+    "admitted_at": "2025-01-15T10:30:00+00:00", "status": "admitted"}))
+VITALS_OLD = [_strip(o) for o in obs_map.vitals_to_fhir({
+    "id": "vit-0", "patient_token": "pt-1", "recorded_at": "2025-01-15T13:00:00+00:00",
+    "pulse": 70, "bp_systolic": 118, "bp_diastolic": 78, "spo2": 99, "is_critical": False})]
+VITALS = [_strip(o) for o in obs_map.vitals_to_fhir({
+    "id": "vit-1", "patient_token": "pt-1", "recorded_at": "2025-01-15T14:00:00+00:00",
+    "pulse": 85, "bp_systolic": 130, "bp_diastolic": 85, "spo2": 96, "is_critical": True})]
+BEDS = [_bed("B1", "ICU-01", "U"), _ward("W1", "ICU")]
+
+PATCHES = []
+OBS_CALLS = []
+
+
+@pytest.fixture
+def client(monkeypatch):
+    PATCHES.clear()
+    OBS_CALLS.clear()
+
+    async def _locations(params): return BEDS
+    async def _encounters(params): return [ADM] if params.get("class") == "IMP" else []
+    async def _observations(params):
+        OBS_CALLS.append(params)
+        return (VITALS_OLD + VITALS) if params.get("category") == "vital-signs" else []
+    async def _read_observation(rid): return VITALS[0] if rid == "vit-1.8867-4" else None
+    async def _patch(rt, rid, ops): PATCHES.append((rt, rid, ops)); return {}
+    async def _try_patch(rt, rid, ops): PATCHES.append((rt, rid, ops)); return True
+    async def _fin_list(base_url, path, **kw): return [{"id": "clm-1", "status": "Pending"}]
+
+    monkeypatch.setattr(fhir_client, "search_locations", _locations)
+    monkeypatch.setattr(fhir_client, "search_encounters", _encounters)
+    monkeypatch.setattr(fhir_client, "search_observations", _observations)
+    monkeypatch.setattr(fhir_client, "read_observation", _read_observation)
+    monkeypatch.setattr(fhir_client, "patch", _patch)
+    monkeypatch.setattr(fhir_client, "try_patch", _try_patch)
+    monkeypatch.setattr(rest_client, "list_", _fin_list)
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_admissions_icu(client):
+    r = client.get("/admissions/icu")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["id"] == "adm-1"
+    assert body[0]["patient_token"] == "pt-1"
+    assert body[0]["bed"]["ward"] == "ICU"
+
+
+def test_beds_available_icu(client):
+    r = client.get("/beds/available-icu")
+    assert r.status_code == 200
+    body = r.json()
+    assert body[0]["id"] == "B1" and body[0]["status"] == "Available" and body[0]["ward"] == "ICU"
+
+
+def test_vitals_latest(client):
+    r = client.get("/vitals/latest?patient=pt-1")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pulse"] == 85 and body["bp_systolic"] == 130
+    assert body["is_critical"] is True
+    assert OBS_CALLS[-1] == {"patient": "pt-1", "category": "vital-signs", "_count": 200}
+
+
+def test_vitals_critical_uses_fhir_interpretation_filter(client):
+    r = client.get("/vitals/critical")
+    assert r.status_code == 200
+    assert r.json()
+    assert OBS_CALLS[-1] == {"category": "vital-signs", "interpretation": "AA", "_count": 200}
+
+
+def test_vital_observation_read(client):
+    r = client.get("/vitals/observations/vit-1.8867-4")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resourceType"] == "Observation"
+    assert body["id"] == "vit-1.8867-4"
+
+
+def test_financial_claims(client):
+    r = client.get("/financial/claims?status=Pending")
+    assert r.status_code == 200
+    assert r.json()[0]["id"] == "clm-1"
+
+
+def test_flag_critical_write(client):
+    # Writes no longer PATCH directly — they queue a PendingChange for the DB to pull.
+    # The bare reading uuid is recorded as record_id; resource_id resolves later.
+    import asyncio
+    from service.change_store import get_change_store
+    store = get_change_store()
+    store._pending.clear(); store._inflight = None
+    r = client.post("/vitals/vit-1/critical")
+    assert r.status_code == 200 and r.json()["is_critical"] is True
+    pending = asyncio.run(store.drain_pending())
+    assert len(pending) == 1
+    c = pending[0]
+    assert c.change_type == "critical_vital" and c.entity == "vital" and c.record_id == "vit-1"
+
+
+def test_set_triage_write(client):
+    # bare visit uuid in -> queued PendingChange targeting the em-prefixed Encounter
+    import asyncio
+    from service.change_store import get_change_store
+    store = get_change_store()
+    store._pending.clear(); store._inflight = None
+    r = client.post("/visits/v-9/triage", json={"score": 2})
+    assert r.status_code == 200 and r.json()["score"] == 2
+    pending = asyncio.run(store.drain_pending())
+    assert len(pending) == 1
+    c = pending[0]
+    assert c.change_type == "triage_score" and c.resource_id == "em-v-9"
+    assert c.entity == "visit" and c.record_id == "v-9"
+
+
+# ─── upstream financial paths (regression guard) ────────────────────────────────
+def test_financial_upstream_paths(monkeypatch):
+    """Pin the exact upstream path per financial read.
+
+    `refunds` in particular is nested under payments; a bare `/refunds` 404s and
+    `safe_list` converts that into an empty list, so a wrong path here is invisible
+    at runtime. These assertions are the only thing that catches it.
+    """
+    import asyncio
+
+    from service import financial
+
+    seen = []
+
+    async def _capture(base_url, path, **params):
+        seen.append(path)
+        return []
+
+    monkeypatch.setattr(financial.rc, "list_", _capture)
+    monkeypatch.setattr(financial.rc, "safe_list", _capture)
+
+    asyncio.run(financial.refunds())
+    asyncio.run(financial.invoices())
+    asyncio.run(financial.claims())
+    asyncio.run(financial.payments())
+    asyncio.run(financial.payment_entries("pay-1"))
+    asyncio.run(financial.invoice_line_items("inv-1"))
+    asyncio.run(financial.claim_line_items("clm-1"))
+    asyncio.run(financial.contracts())
+    asyncio.run(financial.contract_rates("ct-1"))
+
+    assert seen == [
+        "payments/refunds",           # NOT "refunds" — nested under payments upstream
+        "invoices",
+        "claims",
+        "payments",
+        "payments/pay-1/entries",
+        "invoices/inv-1/line_items",  # underscore upstream, hyphen on Fabric's own route
+        "claims/clm-1/line_items",
+        "contracts",
+        "contracts/ct-1/rates",
+    ]

--- a/fabric/tests/test_fhir_mappers.py
+++ b/fabric/tests/test_fhir_mappers.py
@@ -1,0 +1,179 @@
+"""
+Round-trip identity + FHIR validity for the pilot mappers.
+
+The agent contract is preserved because `to_internal(to_fhir(x)) == x` for the
+exact internal projection shapes the poller produces (see src/poller/carerOS_poller.py
+_map_* and src/db/hasura.py read-backs). Validity is checked by re-parsing each
+resource's serialized JSON through its fhir.resources model.
+"""
+
+import json
+
+import pytest
+
+from fhir.resources.location import Location
+from fhir.resources.organization import Organization
+from fhir.resources.encounter import Encounter
+from fhir.resources.observation import Observation
+from fhir.resources.patient import Patient
+
+from fhirgw.mappers import location, organization, encounter, observation, patient
+
+
+# ─── fixtures mirroring the real projection shapes ────────────────────────────
+BEDS = [
+    {  # fully enriched, available
+        "id": "bed-icu-01", "ward": "ICU", "bed_number": "ICU-01", "room_type": "ICU",
+        "status": "Available", "is_active": True, "branch_id": "branch-main",
+        "ventilation": "full_ventilator", "room_sharing": "private", "proximity": 2,
+        "floor": 3, "wing": "North", "natural_light": True, "noise_level": "quiet",
+        "features": ["isolation", "telemetry"],
+    },
+    {  # sparse, Hospilot-owned status, null enrichment, empty features
+        "id": "bed-2", "ward": "General", "bed_number": "2", "room_type": "General",
+        "status": "reserved", "is_active": True, "branch_id": None,
+        "ventilation": None, "room_sharing": None, "proximity": None, "floor": None,
+        "wing": None, "natural_light": None, "noise_level": None, "features": [],
+    },
+    {  # dirty bed (suspended)
+        "id": "bed-3", "ward": "ICU", "bed_number": "ICU-03", "room_type": "ICU",
+        "status": "Dirty", "is_active": True, "branch_id": "branch-main",
+        "ventilation": "oxygen", "room_sharing": "shared_2", "proximity": 5,
+        "floor": 1, "wing": "South", "natural_light": False, "noise_level": "loud",
+        "features": ["telemetry"],
+    },
+]
+
+DEPARTMENTS = [
+    {"id": "dept-icu", "name": "Intensive Care Unit", "type": "icu"},
+    {"id": "dept-x", "name": "", "type": None},
+]
+
+ADMISSIONS = [
+    {"id": "adm-1", "patient_token": "pt-123", "bed_id": "bed-icu-01",
+     "admitted_at": "2025-01-15T10:30:00+00:00", "expected_discharge_at": "2025-01-20T14:00:00+00:00",
+     "status": "admitted"},
+    {"id": "adm-2", "patient_token": "", "bed_id": None,
+     "admitted_at": "2025-01-15T10:30:00", "expected_discharge_at": None,  # naive ts -> ext only
+     "status": "discharging"},
+]
+
+VISITS = [
+    {"id": "v-1", "patient_token": "pt-9", "department_id": "dept-er",
+     "arrived_at": "2025-01-15T16:45:00+00:00", "status": "waiting", "chief_complaint": "Chest pain"},
+    {"id": "v-2", "patient_token": "", "department_id": None,
+     "arrived_at": None, "status": "in_treatment", "chief_complaint": None},
+]
+
+VITALS = [
+    {"id": "vit-1", "patient_token": "pt-1", "admission_id": "adm-1",
+     "recorded_at": "2025-01-15T14:22:00+00:00", "temperature": 37.2, "pulse": 85,
+     "bp_systolic": 130, "bp_diastolic": 85, "spo2": 96, "respiratory_rate": 18,
+     "gcs": 15, "is_critical": False},
+    {"id": "vit-2", "patient_token": "pt-2", "admission_id": None,
+     "recorded_at": "2025-01-15T14:22:00+00:00", "temperature": None, "pulse": 120,
+     "bp_systolic": None, "bp_diastolic": None, "spo2": 88, "respiratory_rate": None,
+     "gcs": None, "is_critical": True},
+]
+
+
+def _revalidate(resource, model_cls):
+    """Serialize then re-parse to assert the resource is structurally valid FHIR."""
+    js = resource.model_dump_json(exclude_none=True, by_alias=True)
+    reparsed = model_cls.model_validate_json(js)
+    assert json.loads(js)["resourceType"] == model_cls.__name__
+    return reparsed
+
+
+# ─── beds ─────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("bed", BEDS, ids=lambda b: b["id"])
+def test_bed_roundtrip(bed):
+    loc = location.to_fhir(bed)
+    _revalidate(loc, Location)
+    assert location.to_internal(loc) == bed
+
+
+def test_bed_upsert_row_is_operational_only():
+    loc = location.to_fhir(BEDS[0])
+    row = location.to_upsert_row(loc)
+    assert set(row) == set(location.OPERATIONAL_KEYS)
+    assert row["status"] == "Available" and row["is_active"] is True
+
+
+# ─── departments ──────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("dept", DEPARTMENTS, ids=lambda d: d["id"])
+def test_department_roundtrip(dept):
+    org = organization.to_fhir(dept)
+    _revalidate(org, Organization)
+    assert organization.to_internal(org) == dept
+
+
+# ─── admissions ───────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("adm", ADMISSIONS, ids=lambda a: a["id"])
+def test_admission_roundtrip(adm):
+    enc = encounter.admission_to_fhir(adm)
+    _revalidate(enc, Encounter)
+    assert encounter.admission_to_internal(enc) == adm
+    assert encounter.to_internal(enc) == adm  # dispatcher picks IMP
+
+
+# ─── visits ───────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("visit", VISITS, ids=lambda v: v["id"])
+def test_visit_roundtrip(visit):
+    enc = encounter.visit_to_fhir(visit)
+    _revalidate(enc, Encounter)
+    assert encounter.visit_to_internal(enc) == visit
+    assert encounter.to_internal(enc) == visit  # dispatcher picks EMER
+
+
+# ─── vitals (numeric-normalized; vitals projection uses raw read-back) ────────
+def _norm_vital(d):
+    out = dict(d)
+    for k in ("temperature", "pulse", "bp_systolic", "bp_diastolic", "spo2", "respiratory_rate", "gcs"):
+        if out.get(k) is not None:
+            out[k] = float(out[k])
+    return out
+
+
+@pytest.mark.parametrize("vital", VITALS, ids=lambda v: v["id"])
+def test_vitals_roundtrip(vital):
+    obs_list = observation.vitals_to_fhir(vital)
+    assert obs_list, "expected at least one Observation"
+    for o in obs_list:
+        _revalidate(o, Observation)
+        assert o.id.split(".")[0] == vital["id"]
+    recovered = observation.vitals_to_internal(obs_list)
+    assert _norm_vital(recovered) == _norm_vital(vital)
+
+
+def test_vitals_bp_panel_has_two_components():
+    obs_list = observation.vitals_to_fhir(VITALS[0])
+    bp = [o for o in obs_list if o.id.endswith(".85354-9")]
+    assert len(bp) == 1 and len(bp[0].component) == 2
+
+
+def test_vitals_critical_sets_interpretation():
+    obs_list = observation.vitals_to_fhir(VITALS[1])  # is_critical=True
+    assert all(o.interpretation for o in obs_list)
+
+
+# ─── labs ─────────────────────────────────────────────────────────────────────
+def test_lab_result_to_observation():
+    row = {"id": "lab-1", "order_id": "o-1", "patient_token": "pt-1",
+           "test_name": "Serum Potassium", "test_code": "K-001", "result_value": "6.8",
+           "flag": "Critical", "reference_range": "3.5-5.0", "unit": "mEq/L",
+           "reported_at": "2025-01-15T09:00:00+00:00"}
+    obs = observation.lab_result_to_observation(row)
+    reparsed = _revalidate(obs, Observation)
+    assert obs.id == "lab-1"
+    assert obs.valueQuantity.value == 6.8
+    assert obs.interpretation  # Critical -> HH
+
+
+# ─── patient (PSEUDONYMOUS — no PHI) ──────────────────────────────────────────
+def test_patient_has_no_phi():
+    p = patient.patient_token_to_patient("pt-123")
+    _revalidate(p, Patient)
+    assert p.name is None and p.birthDate is None and p.gender is None and p.telecom is None
+    assert p.identifier[0].value == "pt-123"
+    assert patient.to_internal(p) == {"patient_token": "pt-123"}

--- a/fabric/tests/test_kafka_payload_first.py
+++ b/fabric/tests/test_kafka_payload_first.py
@@ -1,0 +1,175 @@
+"""Kafka-mode ingest must use the event's own payload for cached entities.
+
+The DB already sends the changed row in the event, so re-reading it over HTTP is
+duplicated work on the DB's server. These tests pin that behaviour: a payload-carrying
+event for a mapped entity must issue NO read, while the fallbacks (no payload, no
+mapper, join-sourced field missing) must still re-read.
+"""
+
+import asyncio
+
+import pytest
+
+from clients import fhir_client
+from ingest import kafka_consumer as kc
+from ingest import kafka_publisher
+
+
+# ─── harness ──────────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _spy(monkeypatch):
+    """Count every outbound read, and capture what gets published."""
+    reads: list[str] = []
+    published: list[tuple] = []
+
+    async def _read_location(rid):
+        reads.append(f"Location/{rid}")
+        return None
+
+    async def _read_encounter(rid):
+        reads.append(f"Encounter/{rid}")
+        return None
+
+    async def _read_observation(rid):
+        reads.append(f"Observation/{rid}")
+        return None
+
+    monkeypatch.setattr(fhir_client, "read_location", _read_location)
+    monkeypatch.setattr(fhir_client, "read_encounter", _read_encounter)
+    monkeypatch.setattr(fhir_client, "read_observation", _read_observation)
+
+    def _searcher(kind):
+        async def _f(params):
+            reads.append(f"{kind}?{params}")
+            return []
+        return _f
+
+    for name, kind in (
+        ("search_service_requests", "ServiceRequest"),
+        ("search_tasks", "Task"),
+        ("search_specimens", "Specimen"),
+        ("search_devices", "Device"),
+        ("search_medication_requests", "MedicationRequest"),
+        ("search_inventory_items", "InventoryItem"),
+        ("search_organizations", "Organization"),
+    ):
+        monkeypatch.setattr(fhir_client, name, _searcher(kind))
+
+    async def _publish(entity, record_id, data, operation="upsert", changed=None):
+        published.append((entity, record_id, data, operation))
+
+    monkeypatch.setattr(kafka_publisher, "publish", _publish)
+
+    _spy.reads = reads
+    _spy.published = published
+    yield
+    reads.clear()
+    published.clear()
+
+
+def _handle(entity, rid, data, operation="upsert"):
+    asyncio.run(kc._handle(entity, rid, operation, data))
+
+
+# ─── payload-first: no read for a cached entity ───────────────────────────────
+BED_ROW = {"id": "b1", "bed_number": "ICU-02", "ward": "ICU",
+           "status": "reserved", "is_active": True, "features": "oxygen,monitor"}
+
+
+def test_bed_event_payload_issues_no_read():
+    _handle("bed", "b1", BED_ROW)
+    assert _spy.reads == [], f"expected zero reads, got {_spy.reads}"
+    entity, rid, data, op = _spy.published[0]
+    assert (entity, rid, op) == ("bed", "b1", "upsert")
+    assert data["ward"] == "ICU" and data["bed_number"] == "ICU-02"
+
+
+def test_raw_status_survives_instead_of_collapsing_to_occupied():
+    """The FHIR path maps reserved -> v2-0116 'O' -> 'Occupied', losing a distinction
+    the consumers test for. The payload path must preserve it."""
+    _handle("bed", "b1", BED_ROW)
+    assert _spy.published[0][2]["status"] == "reserved"
+
+
+def test_admission_payload_keeps_internal_status():
+    _handle("admission", "a1", {"id": "a1", "patient_token": "p1",
+                                "bed_id": "b1", "status": "critical"})
+    assert _spy.reads == []
+    assert _spy.published[0][2]["status"] == "critical"
+
+
+@pytest.mark.parametrize("entity,row", [
+    ("task", {"id": "t1", "admission_id": "a1", "task": "IV abx", "completed": False}),
+    ("lab_result", {"id": "L1", "patient_token": "p1", "flag": "High"}),
+    ("lab_sample", {"id": "s1", "order_id": "o1", "barcode": "BC-1"}),
+    ("lab_analyzer", {"id": "d1", "name": "XN-1000", "status": "active"}),
+    ("pharmacy_inventory", {"id": "i1", "name": "Pip-Taz", "qty_in_stock": 42}),
+    ("visit", {"id": "v1", "patient_token": "p2", "status": "in-progress"}),
+])
+def test_mapped_entities_never_read(entity, row):
+    _handle(entity, row["id"], row)
+    assert _spy.reads == [], f"{entity} should not read; got {_spy.reads}"
+    assert _spy.published, f"{entity} published nothing"
+
+
+def test_lab_topic_publishes_as_lab_order():
+    """Topic suffix is `lab`; the cache keys it as `lab_order`."""
+    _handle("lab", "o1", {"id": "o1", "patient_token": "p1",
+                          "status": "active", "test_name": "CBC"})
+    assert _spy.reads == []
+    assert _spy.published[0][0] == "lab_order"
+
+
+def test_admission_discharge_ready_fans_out_without_extra_read():
+    _handle("admission", "a2", {"id": "a2", "patient_token": "p1",
+                                "discharge_ready": True, "status": "admitted"})
+    assert _spy.reads == []
+    assert [e for e, *_ in _spy.published] == ["admission", "discharge_ready"]
+
+
+# ─── fallbacks: a read is still issued when the payload cannot be trusted ─────
+def test_no_payload_falls_back_to_read():
+    _handle("bed", "b9", None)
+    assert _spy.reads == ["Location/bed-b9"]
+
+
+def test_empty_payload_falls_back_to_read():
+    _handle("admission", "a9", {})
+    assert _spy.reads == ["Encounter/ipd-a9"]
+
+
+def test_payload_without_id_falls_back_to_read():
+    _handle("bed", "b8", {"ward": "ICU", "status": "Available"})
+    assert _spy.reads == ["Location/bed-b8"]
+
+
+def test_lab_order_without_test_name_falls_back_to_read():
+    """test_name lives on the lab_results relation, so a bare orders row is incomplete."""
+    _handle("lab", "o2", {"id": "o2", "patient_token": "p1", "status": "active"})
+    assert _spy.reads and _spy.reads[0].startswith("ServiceRequest?")
+
+
+def test_pharmacy_order_without_medication_falls_back_to_read():
+    _handle("pharmacy_order", "rx1", {"id": "rx1", "patient_token": "p1", "status": "active"})
+    assert _spy.reads and _spy.reads[0].startswith("MedicationRequest?")
+
+
+def test_unmapped_entity_still_reads():
+    """dept has no row mapper and is not cached — behaviour is unchanged."""
+    _handle("dept", "d1", {"id": "d1", "name": "Emergency"})
+    assert _spy.reads and _spy.reads[0].startswith("Organization?")
+
+
+def test_raw_row_entities_pass_through_untouched():
+    """ambulance/ot_* have no FHIR resource; the row is published as-is, no read."""
+    row = {"id": "amb1", "vehicle_no": "KA-01", "status": "available"}
+    _handle("ambulance", "amb1", row)
+    assert _spy.reads == []
+    assert _spy.published[0][2] == row
+
+
+def test_delete_never_reads_and_publishes_null():
+    _handle("bed", "b1", BED_ROW, operation="delete")
+    assert _spy.reads == []
+    entity, rid, data, op = _spy.published[0]
+    assert (entity, op, data) == ("bed", "delete", None)

--- a/fabric/tests/test_pending_changes.py
+++ b/fabric/tests/test_pending_changes.py
@@ -1,0 +1,201 @@
+"""Two-phase pending-changes protocol: state machine + $acknowledge/$confirm flow.
+
+State-machine tests drive ChangeStore directly (via asyncio.run, no pytest-asyncio).
+The API test exercises GET → $acknowledge → $confirm end to end and asserts one Kafka
+ack is published per change with the right entity/id/status.
+"""
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ingest import kafka_publisher
+from service.change_store import (
+    ChangeStore,
+    PendingChange,
+    SnapshotError,
+    get_change_store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_http_pull_mode(monkeypatch):
+    """The pull endpoints are disabled (409) in kafka write mode. These tests exercise
+    the HTTP pull, so pin the mode here rather than inheriting it from the environment."""
+    from config import settings
+    monkeypatch.setattr(settings, "integration_mode", "change_api", raising=False)
+    yield
+
+
+def _change(cid, entity, rid, ctype="bed_status"):
+    return PendingChange(
+        change_type=ctype, resource_type="Location", resource_id=f"bed-{rid}",
+        http_method="PATCH", payload={"code": "U", "display": "Unoccupied"},
+        timestamp="2026-06-12T00:00:00+00:00", change_id=cid, entity=entity, record_id=rid,
+    )
+
+
+# ─── state machine ──────────────────────────────────────────────────────────────
+
+def test_offer_lock_confirm_releases():
+    async def go():
+        store = ChangeStore()
+        await store.add(_change("c1", "bed", "101"))
+        await store.add(_change("c2", "bed", "102"))
+
+        # GET: nothing in flight yet, then commit the drained set
+        assert await store.current_inflight(60) is None
+        drained = await store.drain_pending()
+        assert len(drained) == 2
+        snap = await store.commit_inflight(drained)
+        assert snap is not None and snap.state == "offered"
+
+        # re-pull returns the SAME snapshot (idempotent)
+        again = await store.current_inflight(60)
+        assert again.snapshot_id == snap.snapshot_id
+
+        # $acknowledge locks it
+        locked = await store.mark_locked(snap.snapshot_id)
+        assert locked.state == "locked"
+
+        # $confirm reads changes without releasing, then release clears
+        changes = await store.inflight_changes(snap.snapshot_id)
+        assert {c.change_id for c in changes} == {"c1", "c2"}
+        await store.release(snap.snapshot_id)
+        assert await store.current_inflight(60) is None
+    asyncio.run(go())
+
+
+def test_writes_during_inflight_queue_for_next_pull():
+    async def go():
+        store = ChangeStore()
+        await store.add(_change("c1", "bed", "101"))
+        snap = await store.commit_inflight(await store.drain_pending())
+
+        # a write arrives while c1's snapshot is in flight
+        await store.add(_change("c2", "bed", "102"))
+        # draining is a no-op while a snapshot is in flight
+        assert await store.drain_pending() == []
+
+        # release, then the next pull offers only the queued c2
+        await store.release(snap.snapshot_id)
+        nxt = await store.commit_inflight(await store.drain_pending())
+        assert [c.change_id for c in nxt.changes] == ["c2"]
+    asyncio.run(go())
+
+
+def test_expired_lock_requeues_changes():
+    async def go():
+        store = ChangeStore()
+        await store.add(_change("c1", "bed", "101"))
+        snap = await store.commit_inflight(await store.drain_pending())
+        await store.mark_locked(snap.snapshot_id)
+
+        # with a zero timeout the in-flight snapshot is expired and re-queued
+        assert await store.current_inflight(0) is None
+        reoffered = await store.commit_inflight(await store.drain_pending())
+        assert reoffered.snapshot_id != snap.snapshot_id
+        assert [c.change_id for c in reoffered.changes] == ["c1"]
+    asyncio.run(go())
+
+
+def test_ack_confirm_reject_unknown_snapshot():
+    async def go():
+        store = ChangeStore()
+        with pytest.raises(SnapshotError):
+            await store.mark_locked("nope")
+        with pytest.raises(SnapshotError):
+            await store.inflight_changes("nope")
+    asyncio.run(go())
+
+
+# ─── API end-to-end ──────────────────────────────────────────────────────────────
+
+ACKS = []
+
+
+@pytest.fixture
+def client(monkeypatch):
+    ACKS.clear()
+    # reset the process-wide store between tests
+    store = get_change_store()
+    store._pending.clear()
+    store._inflight = None
+
+    async def _capture(**kw):
+        ACKS.append(kw)
+
+    monkeypatch.setattr(kafka_publisher, "publish_ack", _capture)
+
+    from api.normalized import router as normalized_router
+    from api.fhir import router as fhir_router
+    app = FastAPI()
+    app.include_router(normalized_router)
+    app.include_router(fhir_router)
+    return TestClient(app)
+
+
+def test_two_phase_flow_publishes_one_ack_per_change(client):
+    # queue two writes through the normal write endpoints
+    assert client.post("/beds/B1/status", json={"status": "available"}).status_code == 200
+    assert client.post("/visits/v9/triage", json={"score": 2}).status_code == 200
+
+    # 1. DB pulls the snapshot — one entry per change, each with a change-id fullUrl
+    bundle = client.get("/fhir/Bundle/$pending-changes").json()
+    snapshot_id = bundle["id"]
+    entries = bundle["entry"]
+    assert len(entries) == 2
+    assert all(e["fullUrl"].startswith("urn:hospilot:change:") for e in entries)
+    # every entry carries the DB-side approval flag; an available bed and a triage score
+    # are both auto-appliable (no approval needed)
+    assert all(e["approvalNeeded"] is False for e in entries)
+    change_ids = [e["fullUrl"].split(":")[-1] for e in entries]
+
+    # re-pull is idempotent (same snapshot)
+    assert client.get("/fhir/Bundle/$pending-changes").json()["id"] == snapshot_id
+
+    # 2. receipt — locks
+    ack = client.post("/fhir/Bundle/$pending-changes/$acknowledge", json={"snapshot_id": snapshot_id})
+    assert ack.status_code == 200 and ack.json()["state"] == "locked"
+
+    # 3. confirm — one accepted, one rejected
+    confirm = client.post("/fhir/Bundle/$pending-changes/$confirm", json={
+        "snapshot_id": snapshot_id,
+        "results": [
+            {"change_id": change_ids[0], "status": "accepted"},
+            {"change_id": change_ids[1], "status": "rejected", "reason": "stale"},
+        ],
+    })
+    assert confirm.status_code == 200 and confirm.json()["published"] == 2
+
+    # exactly one ack per change, carrying entity/id/status
+    assert len(ACKS) == 2
+    by_status = {a["status"]: a for a in ACKS}
+    assert set(by_status) == {"accepted", "rejected"}
+    entities = {a["entity"] for a in ACKS}
+    assert entities == {"bed", "visit"}
+    assert by_status["rejected"]["reason"] == "stale"
+
+    # lock released — next pull is empty
+    assert client.get("/fhir/Bundle/$pending-changes").json()["entry"] == []
+
+
+def test_approval_needed_flag_per_change(client):
+    # bed reservation + discharge-ready need approval; cleaning bed does not
+    assert client.post("/beds/B1/status", json={"status": "reserved"}).status_code == 200
+    assert client.post("/beds/B2/status", json={"status": "cleaning"}).status_code == 200
+    assert client.post("/admissions/a7/discharge-ready", json={"ready": True}).status_code == 200
+
+    entries = client.get("/fhir/Bundle/$pending-changes").json()["entry"]
+    approval_by_url = {e["request"]["url"]: e["approvalNeeded"] for e in entries}
+    assert approval_by_url["Location/bed-B1"] is True
+    assert approval_by_url["Location/bed-B2"] is False
+    assert approval_by_url["Encounter/ipd-a7"] is True
+
+
+def test_confirm_unknown_snapshot_is_409(client):
+    r = client.post("/fhir/Bundle/$pending-changes/$confirm",
+                    json={"snapshot_id": "ghost", "results": []})
+    assert r.status_code == 409

--- a/fabric/tests/test_transform.py
+++ b/fabric/tests/test_transform.py
@@ -1,0 +1,141 @@
+"""
+Transform tests — the core job: the DB's STANDARD (extension-free) FHIR R5 → the
+normalized dict shapes the main backend wants.
+
+We build realistic FHIR with the to_fhir mappers, then STRIP all extensions to
+simulate the DB's standard output, and assert the transform recovers the data
+from standard elements (not from Hospilot extensions).
+"""
+
+import json
+
+from fhir.resources.location import Location
+from fhir.resources.patient import Patient
+
+from fhirgw.mappers import location as loc_map, encounter as enc_map, observation as obs_map
+from service import transform as tx
+
+
+class _Obs:
+    """Minimal stand-in for grouping (only .id is read)."""
+    def __init__(self, oid):
+        self.id = oid
+
+
+def test_vitals_grouping_db_measure_prefixed_ids():
+    # the DB emits one Observation per measure, all sharing the reading uuid
+    obs = [_Obs("hr-u1"), _Obs("temp-u1"), _Obs("bp-u1"), _Obs("gcs-u1"), _Obs("hr-u2")]
+    groups = tx.group_vitals_by_reading(obs)
+    assert set(groups.keys()) == {"u1", "u2"}
+    assert len(groups["u1"]) == 4 and len(groups["u2"]) == 1
+
+
+def test_patient_transform():
+    p = Patient(
+        id="tok-1",
+        name=[{"family": "Doe", "given": ["Jane"]}],
+        gender="female", birthDate="1990-01-01",
+        identifier=[{"system": "https://hosp/uhid", "value": "UHID-1"}],
+        telecom=[{"system": "phone", "value": "555-0100"}],
+    )
+    assert tx.patient_token(p) == "tok-1"          # token = Patient.id, not identifier
+    d = tx.patient(p)
+    assert d["patient_token"] == "tok-1"
+    assert d["first_name"] == "Jane" and d["last_name"] == "Doe"
+    assert d["uhid"] == "UHID-1" and d["gender"] == "female"
+
+
+def strip_ext(model):
+    """Return a copy of a fhir.resources model with all `extension` arrays removed."""
+    d = json.loads(model.model_dump_json(exclude_none=True, by_alias=True))
+
+    def _strip(x):
+        if isinstance(x, dict):
+            x.pop("extension", None)
+            return {k: _strip(v) for k, v in x.items()}
+        if isinstance(x, list):
+            return [_strip(i) for i in x]
+        return x
+
+    return type(model).model_validate(_strip(d))
+
+
+def test_admission_from_standard_fhir():
+    enc = strip_ext(enc_map.admission_to_fhir({
+        "id": "adm-1", "patient_token": "pt-1", "bed_id": "B1",
+        "admitted_at": "2025-01-15T10:30:00+00:00", "status": "admitted",
+    }))
+    assert not enc.extension                      # truly standard FHIR
+    d = tx.admission(enc)
+    assert d["id"] == "adm-1"
+    assert d["patient_token"] == "pt-1"
+    assert d["bed_id"] == "B1"
+    assert d["admitted_at"].startswith("2025-01-15T10:30:00")
+    assert d["status"] == "admitted"              # reverse-mapped from in-progress
+
+
+def test_visit_from_standard_fhir():
+    enc = strip_ext(enc_map.visit_to_fhir({
+        "id": "v-1", "patient_token": "pt-2", "department_id": "dept-1",
+        "arrived_at": "2025-01-15T16:00:00+00:00", "status": "waiting",
+        "chief_complaint": "Chest pain", "triage_score": 2,
+    }))
+    d = tx.visit(enc)
+    assert d["patient_token"] == "pt-2"
+    assert d["department_id"] == "dept-1"
+    assert d["chief_complaint"] == "Chest pain"
+    # EMER keeps the FHIR status value (in-progress), not the IMP "admitted" reverse
+    assert d["status"] == "in-progress"
+    # triage_score came from an extension → not recoverable from pure standard FHIR
+    assert d["triage_score"] is None
+
+
+def test_vital_from_standard_fhir():
+    obs = obs_map.vitals_to_fhir({
+        "id": "vit-1", "patient_token": "pt-1", "recorded_at": "2025-01-15T14:00:00+00:00",
+        "temperature": 37.2, "pulse": 85, "bp_systolic": 130, "bp_diastolic": 85,
+        "spo2": 96, "respiratory_rate": 18, "gcs": 15, "is_critical": True,
+    })
+    stripped = [strip_ext(o) for o in obs]
+    d = tx.vital(stripped)
+    assert d["id"] == "vit-1"
+    assert d["patient_token"] == "pt-1"
+    assert d["pulse"] == 85
+    assert d["bp_systolic"] == 130 and d["bp_diastolic"] == 85
+    assert d["gcs"] == 15
+    assert d["recorded_at"].startswith("2025-01-15T14:00:00")   # from effectiveDateTime
+    assert d["is_critical"] is True                              # from interpretation=AA
+
+
+def test_lab_from_standard_fhir():
+    o = strip_ext(obs_map.lab_result_to_observation({
+        "id": "L1", "patient_token": "pt-1", "test_code": "K-001", "test_name": "Serum Potassium",
+        "result_value": "6.8", "unit": "mEq/L", "flag": "Critical", "reference_range": "3.5-5.0",
+        "reported_at": "2025-01-15T13:00:00+00:00",
+    }))
+    d = tx.lab_result(o)
+    assert d["id"] == "L1"
+    assert d["patient_token"] == "pt-1"
+    assert d["test_code"] == "K-001"
+    assert d["result_value"] == 6.8
+    assert d["unit"] == "mEq/L"
+    assert d["flag"] == "Critical"                # reverse-mapped from interpretation HH
+    assert d["reference_range"] == "3.5-5.0"
+
+
+def test_bed_from_standard_partof_ward():
+    # The DB spec exposes ward via partOf → ward Location (form=wa); build that shape.
+    bed = Location(
+        id="B1", status="active", name="ICU-01", mode="instance",
+        form={"coding": [{"system": "http://terminology.hl7.org/CodeSystem/location-physical-type",
+                          "code": "bd", "display": "Bed"}]},
+        operationalStatus={"system": "http://terminology.hl7.org/CodeSystem/v2-0116",
+                           "code": "U", "display": "Unoccupied"},
+        partOf={"reference": "Location/W1"},
+    )
+    d = tx.bed(bed, wards_by_id={"W1": "ICU"})
+    assert d["id"] == "B1"
+    assert d["bed_number"] == "ICU-01"
+    assert d["status"] == "Available"             # from operationalStatus U
+    assert d["ward"] == "ICU"                      # from partOf → ward name
+    assert tx.is_icu_bed(d) is True


### PR DESCRIPTION
Fabric is the transformation layer between the hospital's HIS and Hospilot: it calls the HIS FHIR and financial APIs, maps the responses to FHIR R5, and publishes data-change events over Kafka.

Includes the service and its 72 unit tests, the Dockerfile and compose stack, CI, and a documented .env.example.