### PR TITLE
Fix three bugs found while tracing bed status end to end

### DIFF
--- a/fabric/pyproject.toml
+++ b/fabric/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = [
     "python-dateutil==2.9.0.post0",
     "fhir.resources==8.2.0",
     "fhir-core==1.1.8",
-    # Transitive, but MUST be pinned: fhir-core 1.1.8 imports `SLOTS` from
-    # annotated_types, which 0.8.0 removed.
+    # fhir-core 1.1.8 imports `SLOTS` from annotated-types, removed in 0.8.0.
     "annotated-types==0.7.0",
 ]
 

--- a/fabric/requirements.txt
+++ b/fabric/requirements.txt
@@ -9,9 +9,7 @@ python-dateutil==2.9.0.post0
 # FHIR R5 (5.0.0) resource models — the transformation core
 fhir.resources==8.2.0
 fhir-core==1.1.8
-# Transitive, but MUST be pinned here: fhir-core 1.1.8 imports `SLOTS` from
-# annotated_types, which 0.8.0 removed. Unpinned, pip resolves 0.8.0 and every
-# fhir.resources import fails at collection time.
+# fhir-core 1.1.8 imports `SLOTS` from annotated-types, removed in 0.8.0.
 annotated-types==0.7.0
 
 # Kafka — Fabric publishes data-change events for hospilot-backend to consume

--- a/fabric/src/service/clinical.py
+++ b/fabric/src/service/clinical.py
@@ -23,14 +23,24 @@ PAGE = 200   # DB caps _count at 200
 
 
 # ─── beds ───────────────────────────────────────────────────────────────────────
+def _form_code(loc) -> str | None:
+    """FHIR Location.form code — 'bd' bed, 'wa' ward, 'ro' room.
+
+    A Location models ANY place, so every query that means "beds" has to filter on
+    this. tx.bed() is a mapper, not a validator: hand it a ward and it returns a
+    bed-shaped dict with ward=None, which is how ward records used to leak into
+    /beds/dirty.
+    """
+    return loc.form.coding[0].code if (loc.form and loc.form.coding) else None
+
+
 async def _location_index() -> tuple[dict[str, dict], dict[str, str]]:
     """Active Locations → (beds_by_id, wards_by_id name map). Beds = form 'bd',
     wards = form 'wa' (so partOf can resolve to a ward name)."""
     locs = await fc.search_locations({"status": "active", "_count": PAGE})
     beds_raw, wards = [], {}
     for loc in locs:
-        form = loc.form.coding[0].code if (loc.form and loc.form.coding) else None
-        if form == "wa":
+        if _form_code(loc) == "wa":
             wards[loc.id] = loc.name
         else:
             beds_raw.append(loc)
@@ -52,10 +62,18 @@ async def available_icu_beds() -> list[dict]:
 
 
 async def dirty_beds(icu_only: bool = False) -> list[dict]:
+    """Beds awaiting housekeeping — upstream models these as status=suspended.
+
+    Only form 'bd' Locations count. Wards are permanently suspended upstream (they
+    aren't bookable places), so without this filter every ward is returned as a dirty
+    bed: 8 phantom rows against 4 real ones on the reference dataset.
+    """
     locs = await fc.search_locations({"status": "suspended", "_count": PAGE})
     _, wards = await _location_index()
     out = []
     for loc in locs:
+        if _form_code(loc) != "bd":
+            continue
         b = tx.bed(loc, wards_by_id=wards)
         if icu_only and not tx.is_icu_bed(b):
             continue

--- a/fabric/src/writeback/bundle.py
+++ b/fabric/src/writeback/bundle.py
@@ -64,7 +64,11 @@ def _ops_for(change: PendingChange) -> list[dict]:
     p = change.payload
     match change.change_type:
         case "bed_status":
-            return [{
+            # Two ops, because the FHIR field alone is lossy: reserved / vacating /
+            # occupied all collapse to "O". The extension carries Hospilot's own word so
+            # the HIS receives what we actually meant, and so a read-back returns it
+            # (location.to_internal prefers bed-raw-status over operationalStatus).
+            ops = [{
                 "type": "replace",
                 "path": "Location.operationalStatus",
                 "value_key": "valueCoding",
@@ -74,6 +78,13 @@ def _ops_for(change: PendingChange) -> list[dict]:
                     "display": p["display"],
                 },
             }]
+            if p.get("raw"):
+                ops.append({
+                    "type": "add", "parent": "Location", "name": "extension",
+                    "value_key": "valueExtension",
+                    "value": X.ext_string(X.EXT_BED_RAW_STATUS, p["raw"]),
+                })
+            return ops
         case "triage_score":
             return [{
                 "type": "add", "parent": "Encounter", "name": "extension",

--- a/fabric/src/writeback/proposals.py
+++ b/fabric/src/writeback/proposals.py
@@ -53,6 +53,14 @@ def _pref(prefix: str, rid: str) -> str:
 
 
 async def update_bed_status(bed_id: str, status: str):
+    """Queue a bed status change for the HIS.
+
+    `raw` carries Hospilot's own word alongside the FHIR code, because
+    terminology.operational_status is lossy: reserved, vacating and occupied all map to
+    "O". Sending only the code would tell the HIS "Occupied" when we mean "reserved",
+    so the bundle also writes the bed-raw-status extension (see bundle._ops_for) — the
+    same extension Fabric reads back in fhirgw.mappers.location.to_internal.
+    """
     op = T.operational_status(status)
     if not op:
         raise ValueError(f"Unknown bed status: {status}")
@@ -61,7 +69,7 @@ async def update_bed_status(bed_id: str, status: str):
         resource_type="Location",
         resource_id=_pref("bed-", bed_id),
         http_method="PATCH",
-        payload={"code": op[0], "display": op[1]},
+        payload={"code": op[0], "display": op[1], "raw": status},
         timestamp=now_iso(),
         change_id=new_change_id(),
         entity=CHANGE_TYPE_ENTITY["bed_status"],

--- a/fabric/tests/test_endpoints.py
+++ b/fabric/tests/test_endpoints.py
@@ -207,3 +207,37 @@ def test_financial_upstream_paths(monkeypatch):
         "contracts",
         "contracts/ct-1/rates",
     ]
+
+
+# ─── dirty beds must be beds (regression guard) ─────────────────────────────────
+def _suspended(loc):
+    """Same Location, status=suspended — how upstream marks a bed as needing cleaning."""
+    return type(loc).model_validate({**loc.model_dump(exclude_none=True), "status": "suspended"})
+
+
+def test_dirty_beds_excludes_wards(monkeypatch):
+    """Wards are permanently status=suspended upstream because they aren't bookable.
+
+    tx.bed() maps anything handed to it, so without a form=='bd' filter every ward comes
+    back as a dirty bed (8 phantoms against 4 real ones on the reference dataset). The
+    phantoms have no ward, so they slipped past /beds/dirty-icu but not /beds/dirty --
+    and the SLA evaluator then tracked wards as beds stuck in cleaning forever.
+    """
+    import asyncio
+    from service import clinical
+
+    dirty_bed = _suspended(_bed("B9", "ICU-09", "K"))       # a genuinely dirty ICU bed
+    suspended_wards = [_suspended(_ward("W1", "ICU")), _suspended(_ward("W2", "Cardiology"))]
+
+    async def _locations(params):
+        if params.get("status") == "suspended":
+            return [dirty_bed, *suspended_wards]
+        return [_bed("B1", "ICU-01", "U"), _ward("W1", "ICU")]
+
+    monkeypatch.setattr(fhir_client, "search_locations", _locations)
+
+    out = asyncio.run(clinical.dirty_beds())
+    assert [b["id"] for b in out] == ["B9"], f"wards leaked into dirty beds: {out}"
+
+    icu = asyncio.run(clinical.dirty_beds(icu_only=True))
+    assert [b["id"] for b in icu] == ["B9"]

--- a/fabric/tests/test_pending_changes.py
+++ b/fabric/tests/test_pending_changes.py
@@ -199,3 +199,49 @@ def test_confirm_unknown_snapshot_is_409(client):
     r = client.post("/fhir/Bundle/$pending-changes/$confirm",
                     json={"snapshot_id": "ghost", "results": []})
     assert r.status_code == 409
+
+
+# ─── lossy statuses must ride along in bed-raw-status ────────────────────────────
+def test_bed_status_bundle_carries_raw_status(client):
+    """reserved / vacating / occupied all map to FHIR "O", so the code alone would tell
+    the HIS "Occupied" when we mean "reserved". The Bundle must also set the
+    bed-raw-status extension -- the same one location.to_internal reads back."""
+    from fhirgw import extensions as X
+
+    assert client.post("/beds/B1/status", json={"status": "reserved"}).status_code == 200
+    entry = client.get("/fhir/Bundle/$pending-changes").json()["entry"][0]
+    params = entry["resource"]["parameter"]
+
+    def _part(op, name):
+        return next((p for p in op["part"] if p["name"] == name), None)
+
+    coding = [o for o in params if (_part(o, "path") or {}).get("valueString")
+              == "Location.operationalStatus"]
+    assert len(coding) == 1, "expected the standard operationalStatus op"
+    assert _part(coding[0], "value")["valueCoding"]["code"] == "O"
+
+    exts = [o for o in params if (_part(o, "value") or {}).get("valueExtension")]
+    assert len(exts) == 1, f"expected one extension op, got {len(exts)}"
+    ve = _part(exts[0], "value")["valueExtension"]
+    assert ve["url"] == X.EXT_BED_RAW_STATUS
+    assert ve["valueString"] == "reserved", f"raw status not preserved: {ve}"
+
+
+def test_bed_status_lossless_word_survives_a_round_trip(client):
+    """The write says "reserved"; a read of the resulting resource must say "reserved"
+    too, not the squashed "Occupied"."""
+    from fhirgw import extensions as X
+    from fhirgw.mappers import location as loc_map
+    from fhir.resources.location import Location
+
+    assert client.post("/beds/B3/status", json={"status": "reserved"}).status_code == 200
+    entry = client.get("/fhir/Bundle/$pending-changes").json()["entry"][0]
+    params = entry["resource"]["parameter"]
+    ext = next(p["valueExtension"] for op in params for p in op["part"]
+               if p["name"] == "value" and "valueExtension" in p)
+
+    # apply the patch the way the HIS would, then read it back through Fabric's mapper
+    patched = Location(id="bed-B3", status="active", mode="instance",
+                       operationalStatus={"system": X.EXT_BASE, "code": "O"},
+                       extension=[ext])
+    assert loc_map.to_internal(patched)["status"] == "reserved"


### PR DESCRIPTION
1. /beds/dirty returned wards as beds

   clinical.dirty_beds() mapped every status=suspended Location through tx.bed() without checking Location.form, and wards are permanently suspended upstream because they aren't bookable places. So it returned 12 rows where 4 were real -- 8 wards with ward=None and ids like "ward-cardiology". The raw hospilot.beds table confirms 4.

   get_dirty_beds has 8 consumers in hospilot-backend. The worst is the bed-turnaround SLA evaluator, which tracked each id against a cleaning SLA -- a ward is never cleaned, so those breached forever.

   Extracted _form_code() (the check _location_index already did correctly) and filtered on it. A test asserts a suspended ward never appears in the result.

2. Bed writes told the HIS "Occupied" when they meant "reserved"

   FHIR's occupancy field has no "reserved" -- reserved, vacating and occupied all send code "O". The bed-raw-status extension exists to carry the real word, and the read path already preferred it over the squashed code, but the write path never sent it. Hospilot's own reservations were therefore indistinguishable from real occupancy upstream, and only existed in hospilot-backend's cache.

   update_bed_status now carries the raw word, and bundle._ops_for emits the extension alongside the operationalStatus replace -- the same shape triage_score and discharge_ready already use.

   Verified end to end against the HIS (mock data): patching a bed with operationalStatus=O plus bed-raw-status=reserved persists status='reserved', and Fabric reads back 'reserved'. Extension count stays 1 across repeated writes, since the HIS derives it from the status column rather than storing it, so "add" needs no delete-then-add. The HIS-side change landed separately.

3. annotated-types pin comment aligned with hospilot-internal, where the same pin was made independently.

Verified: 75 tests pass from a clean venv (72 + 3 new), each new test confirmed to fail without its fix. Raw table and Fabric now agree exactly: 22 Available / 35 reserved / 39 Occupied / 4 Dirty.