### PR TITLE
test(ci): cover the untested modules and wire up the unrun suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,89 @@ jobs:
       - run: pip install pytest==8.3.3
       - name: Run tests
         run: python -m pytest
+
+  # ── Cross-app unit tests (tests/) ───────────────────────────────────────────
+  # Modules the per-app suites don't reach: the autonomy policy engine and the
+  # idempotency helper (agentic-framework), the FHIR terminology and identifier
+  # helpers (fabric). Each area is a SEPARATE step, not one pytest run: both apps
+  # define a top-level `config`/`db`/`cache`, so a shared process lets one app's
+  # modules shadow the other's.
+  unit:
+    name: tests/ — cross-app units (py3.12)
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: dummy
+      HASURA_URL: http://localhost/v1/graphql
+      HASURA_ADMIN_SECRET: dummy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: System build deps (psycopg)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev gcc
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r agentic-framework/requirements.txt -r fabric/requirements.txt
+      - run: pip install pytest==8.3.3
+      - name: agentic-framework units
+        run: python -m pytest tests/agentic_framework -q
+      - name: fabric units
+        run: python -m pytest tests/fabric -q
+
+  # ── RL / allocation auction ─────────────────────────────────────────────────
+  # A large suite that was already in the tree but never wired into CI. The
+  # engine needs nothing but PyYAML ("no database, no network" — tests/conftest);
+  # the dev extra adds pytest, httpx (fastapi.testclient) and the API/LLM extras
+  # so the api/matcher tests run instead of skipping.
+  rl:
+    name: RL — pytest (py3.12)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: RL
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev,api,llm]"
+      - name: Run tests
+        run: python -m pytest
+
+  # ── Agentic framework: import smoke test ────────────────────────────────────
+  # No unit-test suite for the app itself yet, so this verifies the app and its
+  # packages import cleanly — it catches broken imports that only bite at boot.
+  agentic:
+    name: agentic-framework — import check (py3.11)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agentic-framework
+    env:
+      PYTHONPATH: .
+      # config.py requires these at import time. Dummy values — no real service
+      # is contacted (connections happen in the app lifespan, not at import).
+      ANTHROPIC_API_KEY: dummy
+      HASURA_URL: http://localhost/v1/graphql
+      HASURA_ADMIN_SECRET: dummy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: agentic-framework/requirements.txt
+      - name: System build deps (psycopg)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev gcc
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - name: Import smoke test
+        run: |
+          python -c "import main; \
+            import messaging.events, messaging.producer, messaging.data_consumer, \
+                   messaging.ack_consumer, messaging.flow_event_relay, \
+                   messaging.initial_sync; \
+            print('agentic-framework imports OK')"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,29 @@
+# Top-level test tree
+
+Unit tests for the modules that the per-app suites do not reach.
+
+Each area runs as its **own pytest process** on purpose: `agentic-framework` and
+`fabric` both define top-level modules named `config`, `db` and `cache`.
+Collecting them in a single process would let one app's modules shadow the
+other's, and the failure looks like an unrelated import error. Each area has its
+own `conftest.py` that puts the right source root on `sys.path`.
+
+```
+tests/
+  agentic_framework/   -> imports from agentic-framework/  (PYTHONPATH=.)
+  fabric/              -> imports from fabric/src/
+```
+
+Nothing here contacts a real service. Settings are satisfied with dummy env
+values set in each `conftest.py`, so the suite is safe to run anywhere.
+
+## Running
+
+```bash
+bash tests/run.sh              # every area, one process each
+python -m pytest tests/fabric -q
+python -m pytest tests/agentic_framework -q
+```
+
+Requires `pytest`, plus each app's own requirements for the area you run.
+In CI these are separate jobs — see `.github/workflows/ci.yml`.

--- a/tests/agentic_framework/conftest.py
+++ b/tests/agentic_framework/conftest.py
@@ -1,0 +1,19 @@
+"""Bootstrap for the agentic-framework test area.
+
+The app runs with the `agentic-framework/` directory as its import root
+(PYTHONPATH=.), so `import config`, `from workflows... import ...` all resolve
+from there. Insert that root here so tests import the same way the app does.
+config.py reads a few settings at import time — dummy values are enough, since
+no real service is contacted during import.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+AGENTIC_ROOT = Path(__file__).resolve().parents[2] / "agentic-framework"
+sys.path.insert(0, str(AGENTIC_ROOT))
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+os.environ.setdefault("HASURA_URL", "http://localhost/v1/graphql")
+os.environ.setdefault("HASURA_ADMIN_SECRET", "dummy")

--- a/tests/agentic_framework/test_idem.py
+++ b/tests/agentic_framework/test_idem.py
@@ -1,0 +1,50 @@
+"""Idempotency-key helper (util/idem.py).
+
+The contract that matters for approval/audit dedup: the same logical action ->
+the same key (so a Temporal activity retry or a LangGraph node re-run collapses
+to ONE row); any difference -> a different key (so genuinely distinct actions in
+one session all survive).
+"""
+
+from util.idem import make_idem_key
+
+
+def test_same_parts_are_stable_and_deterministic():
+    a = make_idem_key("sess-1", "bed_agent", "assign_bed", "bed-7")
+    b = make_idem_key("sess-1", "bed_agent", "assign_bed", "bed-7")
+    assert a == b
+    assert len(a) == 64 and all(c in "0123456789abcdef" for c in a)
+
+
+def test_different_actions_differ():
+    base = ("sess-1", "bed_agent", "assign_bed", "bed-7")
+    assert make_idem_key(*base) != make_idem_key("sess-2", *base[1:])
+    assert make_idem_key(*base) != make_idem_key(base[0], "icu_agent", *base[2:])
+    assert make_idem_key(*base) != make_idem_key(*base[:3], "bed-8")
+
+
+def test_order_is_significant():
+    """('a','b') and ('b','a') are different actions, not the same one reordered."""
+    assert make_idem_key("a", "b") != make_idem_key("b", "a")
+
+
+def test_non_string_parts_are_coerced_stably():
+    """Ids reach this helper as UUIDs, ints or None depending on the caller; the
+    same logical action must not produce two keys because of a type change."""
+    assert make_idem_key(1, 2) == make_idem_key(1, 2)
+    assert make_idem_key(None) == make_idem_key(None)
+    assert make_idem_key({"b": 1, "a": 2}) == make_idem_key({"a": 2, "b": 1})
+
+
+def test_arity_is_significant():
+    """A trailing part must not be absorbed — otherwise two distinct approvals in
+    one session could dedup into a single row and one would be lost."""
+    assert make_idem_key("sess-1", "assign") != make_idem_key("sess-1", "assign", "")
+
+
+def test_no_delimiter_collision_between_adjacent_parts():
+    """Parts are canonicalised structurally, not concatenated, so a value that
+    contains the separator cannot forge a different action's key."""
+    assert make_idem_key("a", "b") != make_idem_key("ab")
+    assert make_idem_key("a,b") != make_idem_key("a", "b")
+    assert make_idem_key("a:b") != make_idem_key("a", "b")

--- a/tests/agentic_framework/test_policy.py
+++ b/tests/agentic_framework/test_policy.py
@@ -1,0 +1,208 @@
+"""Autonomy policy engine (workflows/graph/policy.py).
+
+A pure rule engine: given an interrupt context, `evaluate()` returns a Verdict of
+auto_approve / require_human / escalate, and `dominant()` collapses the verdicts
+of sibling interrupts parked in one superstep. Every test passes an explicit
+policy dict, so none of them touch the on-disk rules file.
+
+The bias under test throughout is fail-safe: when the engine is unsure, the flow
+must park for a human rather than act on its own.
+"""
+
+import pytest
+
+from workflows.graph import policy as p
+
+
+@pytest.fixture(autouse=True)
+def _no_cached_policy():
+    """load_policy() memoises for the process lifetime; drop it around every test
+    so one test's policy can never leak into the next."""
+    p.reset_cache()
+    yield
+    p.reset_cache()
+
+
+def _policy(rules, default=p.REQUIRE_HUMAN):
+    return {"default": default, "rules": rules}
+
+
+# ── DEFAULT_POLICY: the built-in, human-safe fallback ────────────────────────
+
+def test_default_policy_risk_tiers():
+    d = p.DEFAULT_POLICY
+    assert p.evaluate({"risk": "low"}, d).outcome == p.AUTO_APPROVE
+    assert p.evaluate({"risk": "medium"}, d).outcome == p.REQUIRE_HUMAN
+    assert p.evaluate({"risk": "high"}, d).outcome == p.ESCALATE
+
+
+def test_default_policy_sensitive_kinds_never_auto_resolve():
+    """These are listed ahead of the risk tiers on purpose: even tagged low risk,
+    identifying or registering a patient (or a user-requested pause) needs a human."""
+    for kind in ("patient_identification", "patient_registration", "user_paused"):
+        v = p.evaluate({"kind": kind, "risk": "low"}, p.DEFAULT_POLICY)
+        assert v.outcome == p.REQUIRE_HUMAN, f"{kind} auto-resolved"
+
+
+def test_no_match_falls_back_to_default():
+    v = p.evaluate({"risk": "unclassified"}, p.DEFAULT_POLICY)
+    assert v.outcome == p.REQUIRE_HUMAN
+    assert v.rule is None
+
+
+# ── matching semantics ───────────────────────────────────────────────────────
+
+def test_first_matching_rule_wins():
+    """Rule order is rule priority."""
+    pol = _policy([
+        {"match": {"risk": "high"}, "outcome": p.AUTO_APPROVE, "decision": "approved"},
+        {"match": {"risk": "high"}, "outcome": p.ESCALATE},
+    ])
+    assert p.evaluate({"risk": "high"}, pol).outcome == p.AUTO_APPROVE
+
+
+def test_match_is_case_insensitive():
+    pol = _policy([{"match": {"kind": "Bed_Assignment"}, "outcome": p.AUTO_APPROVE}])
+    assert p.evaluate({"kind": "BED_ASSIGNMENT"}, pol).outcome == p.AUTO_APPROVE
+    assert p.evaluate({"kind": "  bed_assignment  "}, pol).outcome == p.AUTO_APPROVE
+
+
+def test_list_match_is_membership():
+    pol = _policy([
+        {"match": {"risk": ["low", "medium"]}, "outcome": p.AUTO_APPROVE},
+    ])
+    assert p.evaluate({"risk": "medium"}, pol).outcome == p.AUTO_APPROVE
+    assert p.evaluate({"risk": "high"}, pol).outcome == p.REQUIRE_HUMAN
+
+
+def test_all_keys_must_match():
+    """A rule is an AND across its match keys — a partial match must not fire."""
+    pol = _policy([
+        {"match": {"kind": "staff", "risk": "low"}, "outcome": p.AUTO_APPROVE},
+    ])
+    assert p.evaluate({"kind": "staff", "risk": "low"}, pol).outcome == p.AUTO_APPROVE
+    assert p.evaluate({"kind": "staff", "risk": "high"}, pol).outcome == p.REQUIRE_HUMAN
+    assert p.evaluate({"kind": "staff"}, pol).outcome == p.REQUIRE_HUMAN
+
+
+def test_missing_context_key_does_not_match():
+    """An absent key must never be treated as a wildcard."""
+    pol = _policy([{"match": {"agent_id": "bed_agent"}, "outcome": p.AUTO_APPROVE}])
+    assert p.evaluate({}, pol).outcome == p.REQUIRE_HUMAN
+
+
+def test_non_string_payload_extras_match_by_value():
+    """Interrupt payload extras (bed_id, count, ...) arrive as ints/bools."""
+    pol = _policy([{"match": {"count": 3}, "outcome": p.AUTO_APPROVE}])
+    assert p.evaluate({"count": 3}, pol).outcome == p.AUTO_APPROVE
+    assert p.evaluate({"count": 4}, pol).outcome == p.REQUIRE_HUMAN
+
+
+def test_empty_match_is_a_catch_all():
+    """`all()` over no keys is True, so `{}` matches everything — the documented
+    way to write a terminal rule."""
+    pol = _policy([{"match": {}, "outcome": p.ESCALATE}])
+    assert p.evaluate({"anything": "at all"}, pol).outcome == p.ESCALATE
+
+
+def test_verdict_carries_the_matched_rule_and_a_reason():
+    """The reason string is what reaches the websocket and the audit row."""
+    rule = {"match": {"risk": "low"}, "outcome": p.AUTO_APPROVE, "decision": "ok"}
+    v = p.evaluate({"risk": "low"}, _policy([rule]))
+    assert v.rule["match"] == {"risk": "low"}
+    assert v.decision == "ok"
+    assert v.reason
+
+
+# ── loading / normalisation robustness ───────────────────────────────────────
+
+def test_normalise_drops_malformed_rules_and_bad_default():
+    """A partly-bad file must still yield a usable policy rather than raising."""
+    got = p._normalise({
+        "default": "nonsense",
+        "rules": [
+            "not-an-object",
+            {"match": {"risk": "low"}, "outcome": "teleport"},   # bad outcome
+            {"match": "not-an-object", "outcome": p.AUTO_APPROVE},
+            {"match": {"risk": "low"}, "outcome": p.AUTO_APPROVE},  # the only good one
+        ],
+    })
+    assert got["default"] == p.REQUIRE_HUMAN
+    assert len(got["rules"]) == 1
+    assert got["rules"][0]["match"] == {"risk": "low"}
+
+
+def test_normalise_applies_rule_defaults():
+    got = p._normalise({"rules": [{"match": {}, "outcome": p.AUTO_APPROVE}]})
+    assert got["rules"][0]["decision"] == "approved"
+    assert got["rules"][0]["notify"] is True
+
+
+def test_normalise_rejects_a_non_object_root():
+    with pytest.raises(ValueError):
+        p._normalise(["not", "a", "dict"])
+
+
+def test_normalise_tolerates_missing_and_null_rules():
+    for raw in ({}, {"rules": None}, {"rules": []}):
+        assert p._normalise(raw)["rules"] == []
+
+
+# ── dominant(): collapsing sibling verdicts ──────────────────────────────────
+
+def test_dominant_unanimous_auto_approve():
+    vs = [p.Verdict(outcome=p.AUTO_APPROVE, decision="approved") for _ in range(3)]
+    assert p.dominant(vs).outcome == p.AUTO_APPROVE
+
+
+def test_dominant_highest_severity_wins():
+    vs = [
+        p.Verdict(outcome=p.AUTO_APPROVE),
+        p.Verdict(outcome=p.REQUIRE_HUMAN),
+        p.Verdict(outcome=p.ESCALATE),
+    ]
+    assert p.dominant(vs).outcome == p.ESCALATE
+
+
+def test_dominant_mixed_auto_decisions_parks_for_human():
+    """All siblings auto-approve, but with different resume values. One
+    Command(resume=...) can't satisfy both, so park rather than mis-deliver."""
+    vs = [
+        p.Verdict(outcome=p.AUTO_APPROVE, decision="approved"),
+        p.Verdict(outcome=p.AUTO_APPROVE, decision="rejected"),
+    ]
+    assert p.dominant(vs).outcome == p.REQUIRE_HUMAN
+
+
+def test_dominant_single_verdict_passes_through_untouched():
+    v = p.Verdict(outcome=p.AUTO_APPROVE, decision="approved", reason="only one")
+    assert p.dominant([v]) is v
+
+
+def test_dominant_empty_is_require_human():
+    assert p.dominant([]).outcome == p.REQUIRE_HUMAN
+
+
+# ── fail-safe ────────────────────────────────────────────────────────────────
+
+def test_evaluate_never_raises_on_bad_policy():
+    """Policy evaluation must never break a run: anything unusable parks for a
+    human instead of propagating."""
+    for bad in ({"rules": [{"no_match_key": 1}]}, {"rules": "not-a-list"},
+                {"rules": [None]}, {"rules": [{"match": {}}]}):
+        assert p.evaluate({"risk": "low"}, bad).outcome == p.REQUIRE_HUMAN
+
+
+def test_evaluate_with_no_rules_uses_the_stated_default():
+    """An empty rule list isn't an error — it's a policy that defers everything."""
+    assert p.evaluate({"risk": "low"}, {"rules": []}).outcome == p.REQUIRE_HUMAN
+    assert p.evaluate({"risk": "low"}, {"default": p.ESCALATE, "rules": []}).outcome == p.ESCALATE
+
+
+def test_evaluate_survives_an_exploding_context():
+    class Boom:
+        def __str__(self):  # noqa: D105
+            raise RuntimeError("cannot stringify")
+
+    pol = _policy([{"match": {"risk": "low"}, "outcome": p.AUTO_APPROVE}])
+    assert p.evaluate({"risk": Boom()}, pol).outcome == p.REQUIRE_HUMAN

--- a/tests/fabric/conftest.py
+++ b/tests/fabric/conftest.py
@@ -1,0 +1,17 @@
+"""Bootstrap for the fabric test area.
+
+Fabric runs with `src/` as its import root, so mirror that here and set the same
+safe env defaults fabric/tests/conftest.py uses — settings then resolve without
+any real upstream being contacted.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+FABRIC_SRC = Path(__file__).resolve().parents[2] / "fabric" / "src"
+sys.path.insert(0, str(FABRIC_SRC))
+
+os.environ.setdefault("EHR_FHIR_BASE_URL", "http://localhost:3001/fhir")
+os.environ.setdefault("FINANCIAL_API_BASE_URL", "http://localhost:3001/api/financial")
+os.environ.setdefault("FABRIC_API_KEY", "")  # fabric auth disabled in tests

--- a/tests/fabric/test_identifiers.py
+++ b/tests/fabric/test_identifiers.py
@@ -1,0 +1,72 @@
+"""FHIR identifier/reference helpers (fhirgw/identifiers.py).
+
+These build the namespaced `system` URIs and relative references every mapper
+depends on. Identifier systems are derived from settings.fhir_base_url so they
+are stable per-deployment — assertions are made relative to that base rather
+than hard-coding a host.
+"""
+
+from config import settings
+from fhirgw import identifiers as ident
+
+BASE = settings.fhir_base_url.rstrip("/")
+
+# Every system helper, with the suffix each one owns.
+SYSTEMS = [
+    (ident.sys_patient_token, "/identifier/patient-token"),
+    (ident.sys_admission,     "/identifier/admission"),
+    (ident.sys_visit,         "/identifier/visit"),
+    (ident.sys_bed,           "/identifier/bed"),
+    (ident.sys_department,    "/identifier/department"),
+    (ident.sys_organization,  "/identifier/organization"),
+    (ident.sys_vital,         "/identifier/vital"),
+    (ident.sys_lab,           "/identifier/lab-result"),
+    (ident.sys_lab_code,      "/CodeSystem/lab-test-code"),
+]
+
+
+def test_reference_is_a_relative_fhir_reference():
+    assert ident.reference("Patient", "p1") == {"reference": "Patient/p1"}
+    assert ident.patient_reference("tok-1") == {"reference": "Patient/tok-1"}
+
+
+def test_reference_has_no_absolute_url():
+    """Relative references keep the bundle portable across deployments."""
+    ref = ident.reference("Location", "bed-1")["reference"]
+    assert not ref.startswith("http")
+    assert ref.count("/") == 1
+
+
+def test_identifier_stringifies_value():
+    """Ids arrive as UUIDs, ints or strings; FHIR requires a string value."""
+    assert ident.identifier("sys", 42) == {"system": "sys", "value": "42"}
+    assert ident.identifier("sys", "abc")["value"] == "abc"
+
+
+def test_reference_stringifies_non_string_ids():
+    assert ident.reference("Encounter", 7) == {"reference": "Encounter/7"}
+
+
+def test_patient_identifier_uses_the_patient_token_system():
+    got = ident.patient_identifier("tok-9")
+    assert got == {"system": ident.sys_patient_token(), "value": "tok-9"}
+
+
+def test_identifier_systems_share_the_configured_base():
+    for fn, suffix in SYSTEMS:
+        assert fn() == f"{BASE}{suffix}", f"{fn.__name__} drifted from the base"
+
+
+def test_identifier_systems_are_all_distinct():
+    """Admission-vs-visit and vital-vs-lab need separate systems so a future
+    write-back can route a resource to the correct Hospilot table."""
+    values = [fn() for fn, _ in SYSTEMS]
+    assert len(values) == len(set(values))
+
+
+def test_source_organization_reference_tracks_ehr_source():
+    oid = ident.source_organization_id()
+    assert oid == f"source-{settings.ehr_source}"
+    assert ident.source_organization_reference() == {
+        "reference": f"Organization/{oid}"
+    }

--- a/tests/fabric/test_terminology.py
+++ b/tests/fabric/test_terminology.py
@@ -1,0 +1,152 @@
+"""Terminology maps + coders (fhirgw/terminology.py).
+
+The single source of truth for the FHIR codings the mappers emit. These are the
+plain-string -> coding translations the outbound API and search both rely on, so
+a silent change to a code, or a reverse map that stops agreeing with the forward
+map, is a data-contract bug rather than a cosmetic one.
+"""
+
+import pytest
+
+from fhirgw import terminology as t
+
+
+# ── vitals LOINC catalog ─────────────────────────────────────────────────────
+
+def test_vitals_codes_covers_every_vital_and_bp_component():
+    """VITALS_CODES drives `GET /fhir/Observation/{id}` dispatch. A vital whose
+    code is missing here becomes unreadable by id even though it maps fine."""
+    for code, _display, _unit in t.VITALS_LOINC.values():
+        assert code in t.VITALS_CODES
+    for code, *_ in (t.BP_PANEL_CODE, t.BP_SYSTOLIC, t.BP_DIASTOLIC):
+        assert code in t.VITALS_CODES
+
+
+def test_every_vital_carries_a_code_display_and_ucum_unit():
+    for field, entry in t.VITALS_LOINC.items():
+        code, display, unit = entry
+        assert code and display and unit, f"{field} has an empty coding element"
+
+
+def test_vitals_loinc_codes_are_unique():
+    """Two vitals sharing a LOINC code would make read-by-code ambiguous."""
+    codes = [c for c, _d, _u in t.VITALS_LOINC.values()]
+    assert len(codes) == len(set(codes))
+
+
+def test_spo2_carries_the_required_magic_pulse_ox_coding():
+    """The FHIR `oxygensat` profile rejects the resource unless LOINC 2708-6 is
+    present alongside our specific pulse-ox code."""
+    spo2_code = t.VITALS_LOINC["spo2"][0]
+    assert spo2_code == "59408-5"
+    assert t.VITAL_REQUIRED_CODINGS[spo2_code] == (
+        "2708-6", "Oxygen saturation in Arterial blood",
+    )
+
+
+def test_gcs_code_agrees_with_the_catalog():
+    """GCS is emitted as valueInteger keyed off GCS_CODE; if that drifts from the
+    catalog entry the score silently stops being recognised as a GCS."""
+    assert t.GCS_CODE == t.VITALS_LOINC["gcs"][0]
+
+
+# ── encounter status round-trip ──────────────────────────────────────────────
+
+@pytest.mark.parametrize("internal,fhir", [
+    ("admitted", "in-progress"),
+    ("discharging", "discharged"),
+    ("in_treatment", "in-progress"),
+    ("discharged", "completed"),
+    ("waiting", "in-progress"),
+    ("triaged", "in-progress"),
+    ("cancelled", "cancelled"),
+])
+def test_encounter_status_to_fhir(internal, fhir):
+    assert t.encounter_status_to_fhir(internal) == fhir
+
+
+def test_encounter_status_to_fhir_is_case_insensitive_and_defaults_unknown():
+    assert t.encounter_status_to_fhir("ADMITTED") == "in-progress"
+    assert t.encounter_status_to_fhir("Discharged") == "completed"
+    assert t.encounter_status_to_fhir("nonsense") == "unknown"
+    assert t.encounter_status_to_fhir(None) == "unknown"
+    assert t.encounter_status_to_fhir("") == "unknown"
+
+
+def test_encounter_status_reverse_map_is_consistent():
+    """Every internal status must be recoverable from the FHIR status it maps to.
+    This is what makes `?status=` search return the same rows the mapper wrote."""
+    for internal, fhir in t.ENCOUNTER_STATUS_MAP.items():
+        assert internal in t.encounter_status_to_internal(fhir), (
+            f"{internal!r} -> {fhir!r} but the reverse map loses it"
+        )
+
+
+def test_encounter_status_to_internal_unknown_passes_through():
+    """An unmapped status is echoed back so a search for it yields nothing rather
+    than silently matching everything."""
+    assert t.encounter_status_to_internal("planned") == ["planned"]
+
+
+# ── lab interpretation ───────────────────────────────────────────────────────
+
+def test_interpretation_map_covers_the_hospilot_flags():
+    assert t.INTERPRETATION_MAP["Normal"] == ("N", "Normal")
+    assert t.INTERPRETATION_MAP["Low"] == ("L", "Low")
+    assert t.INTERPRETATION_MAP["High"] == ("H", "High")
+    assert t.INTERPRETATION_MAP["Critical"] == ("HH", "Critical high")
+
+
+def test_critical_vital_interpretation_is_distinct_from_the_lab_critical():
+    """A critical vital is AA (abnormal), a critical lab is HH (high). Collapsing
+    them would misreport one of the two."""
+    assert t.CRITICAL_INTERP == ("AA", "Critical abnormal")
+    assert t.CRITICAL_INTERP != t.INTERPRETATION_MAP["Critical"]
+
+
+# ── location status + operational status ─────────────────────────────────────
+
+def test_location_status():
+    assert t.location_status(True, "Available") == "active"
+    assert t.location_status(True, "Occupied") == "active"
+    assert t.location_status(True, "Dirty") == "suspended"
+    assert t.location_status(True, "Cleaning") == "suspended"
+    assert t.location_status(False, "Available") == "inactive"
+
+
+def test_location_status_inactive_wins_over_a_suspended_status():
+    """A decommissioned bed is inactive regardless of how dirty it is."""
+    assert t.location_status(False, "Dirty") == "inactive"
+
+
+def test_operational_status_maps_bed_status_and_is_case_insensitive():
+    assert t.operational_status("Available") == ("U", "Unoccupied")
+    assert t.operational_status("available") == ("U", "Unoccupied")
+    assert t.operational_status("OCCUPIED") == ("O", "Occupied")
+    assert t.operational_status("Dirty") == ("K", "Contaminated")
+    assert t.operational_status("Cleaning") == ("H", "Housekeeping")
+
+
+def test_operational_status_unknown_is_none_not_a_guess():
+    """An unrecognised bed status must omit operationalStatus rather than assert a
+    wrong one — a bed wrongly coded Unoccupied would be offered to a patient."""
+    assert t.operational_status("teleported") is None
+    assert t.operational_status(None) is None
+    assert t.operational_status("") is None
+
+
+def test_reserved_and_vacating_beds_are_not_free():
+    """Both are transitional but neither is allocatable; they must code Occupied."""
+    assert t.operational_status("reserved") == ("O", "Occupied")
+    assert t.operational_status("vacating") == ("O", "Occupied")
+
+
+# ── triage priority ──────────────────────────────────────────────────────────
+
+def test_triage_priority_covers_ctas_1_to_5_and_is_monotonic():
+    """CTAS 1 is the most urgent; urgency must never increase as the number grows."""
+    assert set(t.TRIAGE_PRIORITY) == {1, 2, 3, 4, 5}
+    rank = {"EM": 0, "UR": 1, "R": 2}
+    codes = [t.TRIAGE_PRIORITY[i][0] for i in range(1, 6)]
+    assert codes == ["EM", "UR", "UR", "R", "R"]
+    assert rank[codes[0]] <= rank[codes[-1]]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run the top-level test tree.
+#
+# Each area runs as its OWN process on purpose: agentic-framework and fabric both
+# define top-level modules named `config`/`db`/`cache`. Collecting them in a
+# single pytest process would let one app's modules shadow the other's, and the
+# failure surfaces as a confusing unrelated import error. Each area has its own
+# conftest putting the right source root on sys.path.
+#
+# Usage:
+#   bash tests/run.sh
+#   PYTHON=path/to/python bash tests/run.sh
+#
+# Requires pytest, plus each app's own requirements for the area being run.
+# In CI these are separate jobs — see .github/workflows/ci.yml.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+
+PASS=0; FAIL=0
+run() {  # run <label> <cmd...>
+  local label="$1"; shift
+  echo ""
+  echo "▶ $label"
+  if "$@"; then echo "  PASS  $label"; PASS=$((PASS+1))
+  else          echo "  FAIL  $label"; FAIL=$((FAIL+1)); fi
+}
+
+run "agentic-framework" "$PYTHON" -m pytest "$ROOT/tests/agentic_framework" -q
+run "fabric"            "$PYTHON" -m pytest "$ROOT/tests/fabric" -q
+
+echo ""
+echo "── $PASS area(s) passed · $FAIL failed ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
CI ran a single job (fabric), so most of the tree was unverified on a merge to main. This adds unit tests for the modules no suite reached, and wires up the suites that already existed but were never run.

New tests (tests/, 60 cases):
  agentic_framework/test_policy.py  autonomy policy engine — the default
    risk tiers, sensitive kinds that must never auto-resolve, rule matching
    (order, case, list membership, AND across keys), normalisation of a
    partly-malformed rules file, dominant() collapsing sibling verdicts, and
    the fail-safe that parks for a human instead of raising.
  agentic_framework/test_idem.py    idempotency keys — stable for one logical
    action, distinct for any difference, and no delimiter collision that could
    let two approvals dedup into one row.
  fabric/test_terminology.py        the FHIR coding contract — vitals LOINC
    catalog, the magic pulse-ox coding the oxygensat profile requires,
    encounter-status forward/reverse agreement, bed operational status
    (including unknown -> None, so a bed is never wrongly coded free), and
    triage priority.
  fabric/test_identifiers.py        namespaced identifier systems and relative
    references, asserted against fhir_base_url rather than a hard-coded host.

Each area runs as its own pytest process: agentic-framework and fabric both define a top-level config/db/cache, and a shared process lets one shadow the other. tests/run.sh does this locally, CI does it as separate steps.

CI also gains two jobs for suites that were already in the tree but unrun: RL (466 cases, no DB or network) and an agentic-framework import smoke test.

Note: RL/tests/test_api.py needs Python 3.12 — allocation/api/__main__.py:113 uses a multi-line expression inside an f-string (PEP 701), which is a syntax error on the 3.11 that RL/pyproject.toml declares as its floor. The job is pinned to 3.12; the floor and that f-string want reconciling separately.

## What does this change?

<!-- One or two sentences. What's different after this PR, and why. -->

## Which service(s)?

- [x] `agentic-framework`
- [x] `fabric`
- [ ] docs / README only

## Testing

<!-- What did you run to confirm this works? `python -m pytest` output, a manual repro
     steps, etc. A PR with no testing notes is harder to review, not faster. -->

## Checklist

- [x] Tests pass locally (`python -m pytest` in the service(s) you touched)
- [x] New behavior has test coverage
- [ ] Scoped to one change — no unrelated reformatting/renaming mixed in
