### PR TITLE
perf(fabric): cut redundant Fabric reads; tolerate raw HIS values in …

### DIFF
--- a/agentic-framework/agents/_shared/vitals_bulk.py
+++ b/agentic-framework/agents/_shared/vitals_bulk.py
@@ -1,0 +1,112 @@
+"""Bulk vitals prefetch -- shared by every agent that needs vitals for many patients.
+
+The problem this solves: `/vitals/latest` is per-patient because `patient` is the
+only patient-scoping search param the upstream FHIR server advertises (its
+CapabilityStatement lists exactly patient, category, code, interpretation,
+_count; $lastn, $export, batch Bundles and a CSV `patient` are all absent, and
+`subject` is silently ignored). So agents that need N patients wrote a `for` loop
+around one call each:
+
+    agents/er/activities.py       -- one call per active ER visit (65 on the
+                                     reference dataset, 65 serial calls)
+    agents/icu/activities.py      -- one call per admission, hospital-wide
+    agents/discharge/activities.py, agents/bed/agent_activities.py,
+    rag/sql_engine.py, workflows/graph/patient.py
+
+Fabric's /vitals/latest-bulk does one unfiltered vital-signs search and groups by
+subject, so N patients cost ONE call. Measured: 27 patients in 0.24s vs 27 calls
+in 3.49s, with byte-identical readings (same id and recorded_at) for every
+patient.
+
+Two failure modes are handled here rather than at each call site, because getting
+either wrong means analysing a patient as though they had no vitals:
+
+  * TRUNCATION -- the upstream cannot page (it ignores _offset and emits no
+    `next` link), so a hospital with more Observations than one response carries
+    would get a silent prefix. hasura.get_latest_vitals_bulk reports that and
+    re-reads the missing tokens per-patient.
+  * OUTAGE -- if the bulk endpoint fails outright we fall back to the original
+    per-patient path (bounded concurrency) rather than return an empty map.
+"""
+
+import asyncio
+import logging
+
+from db.hasura import hasura
+from fhirgw import repository as repo
+from fhirgw.mappers import observation as obs_map
+from fhirgw.mappers._common import ref_id
+
+logger = logging.getLogger("vitals_bulk")
+
+# Ceiling on patients pulled in one sweep. The bulk read is a single call, so this
+# is not about call volume -- it bounds the per-patient fallback and the payload
+# handed to the LLM. Sized above a large hospital's active census; if it ever
+# bites it logs rather than silently analysing a subset.
+VITALS_PATIENT_CAP = 500
+
+_FALLBACK_CONCURRENCY = 10
+
+
+def tokens_from_encounters(encounters) -> list[str]:
+    """Deduped patient tokens from FHIR Encounters, order preserved.
+
+    Dedup matters: the same patient can hold several admissions, and callers
+    often merge two populations (ICU + non-ICU) that overlap.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for enc in encounters:
+        tok = ref_id(enc.subject)
+        if tok and tok not in seen:
+            seen.add(tok)
+            out.append(tok)
+    return out
+
+
+async def _per_patient(tokens: list[str]) -> dict[str, list]:
+    """Original path: one call per token, bounded concurrency."""
+    out: dict[str, list] = {}
+    sem = asyncio.Semaphore(_FALLBACK_CONCURRENCY)
+
+    async def _one(tok: str) -> None:
+        async with sem:
+            try:
+                out[tok] = await repo.latest_vitals(tok)
+            except Exception:  # noqa: BLE001 -- one patient must not fail the sweep
+                out[tok] = []
+
+    await asyncio.gather(*[_one(t) for t in tokens])
+    return out
+
+
+async def bulk_vitals_observations(tokens: list[str]) -> dict[str, list]:
+    """{token: [FHIR Observation]} for many patients in one Fabric call.
+
+    Returns the same shape repo.latest_vitals gives per patient, so callers keep
+    feeding is_critical / vitals_to_internal / the ranking helpers unchanged.
+    Tokens with no vitals are simply absent from the map.
+    """
+    if not tokens:
+        return {}
+    if len(tokens) > VITALS_PATIENT_CAP:
+        logger.warning("vitals sweep capped at %d of %d patients",
+                       VITALS_PATIENT_CAP, len(tokens))
+        tokens = tokens[:VITALS_PATIENT_CAP]
+
+    try:
+        rows = await hasura.get_latest_vitals_bulk(tokens)
+    except Exception as exc:  # noqa: BLE001 -- bulk is an optimization, never a hard dep
+        logger.warning("bulk vitals unavailable, per-patient fallback: %s", exc)
+        return await _per_patient(tokens)
+
+    converted: dict[str, list] = {}
+    for tok in tokens:
+        row = rows.get(tok)
+        if not row:
+            continue
+        try:
+            converted[tok] = obs_map.vitals_to_fhir({**row, "patient_token": tok})
+        except Exception as exc:  # noqa: BLE001 -- a bad row must not fail the sweep
+            logger.warning("could not map bulk vitals for %s: %s", tok[:8], exc)
+    return converted

--- a/agentic-framework/agents/er/activities.py
+++ b/agentic-framework/agents/er/activities.py
@@ -10,6 +10,7 @@ from cache import redis as cache
 from db.hasura import hasura
 from fhirgw import repository as repo
 from fhirgw.mappers._common import ref_id, reason_text, bare_id
+from agents._shared.vitals_bulk import bulk_vitals_observations, tokens_from_encounters
 from agents.er.service import triage_er_visits
 from api.routes.ws import broadcast
 
@@ -89,10 +90,15 @@ async def triage_er_patients(inp: ErTriageInput) -> list:
     now = datetime.now(timezone.utc)
     # inp.visits are FHIR Encounter (EMER) JSON; re-parse and fetch vitals as FHIR Observations.
     encounters = [Encounter.model_validate(e) for e in inp.visits]
+    # Vitals for the whole ER census in ONE Fabric call. This loop used to await
+    # repo.latest_vitals() per visit, so triage cost one call per active ER
+    # patient -- 65 serial calls on the reference dataset, and the single largest
+    # contributor to a live flow's Fabric traffic.
+    vitals_by_token = await bulk_vitals_observations(tokens_from_encounters(encounters))
     items = []
     for enc in encounters:
         token = ref_id(enc.subject)
-        vitals = await repo.latest_vitals(token) if token else []
+        vitals = vitals_by_token.get(token, []) if token else []
         arrived = _enc_arrived(enc)
         wait_minutes = 0
         if arrived is not None:

--- a/agentic-framework/agents/icu/activities.py
+++ b/agentic-framework/agents/icu/activities.py
@@ -1,4 +1,5 @@
-﻿import logging
+﻿import asyncio
+import logging
 from dataclasses import dataclass
 
 from temporalio import activity
@@ -11,6 +12,7 @@ from fhirgw import repository as repo
 from fhirgw.mappers import observation as obs_map
 from fhirgw.mappers._common import ref_id
 from agents.icu.service import analyze_icu, rank_icu_admissions, is_critical
+from agents._shared.vitals_bulk import bulk_vitals_observations, tokens_from_encounters
 from util.idem import make_idem_key
 from workflows.temporal.workflow._escalation import start_escalating_approval
 from api.routes.ws import broadcast
@@ -124,21 +126,35 @@ async def analyze_icu_status(inp: IcuAnalysisInput) -> dict:
         bid = _enc_bed_id(enc)
         return bed_by_id.get(bid) if bid else None
 
-    # Fetch vitals (FHIR Observations) for ICU patients
-    icu_with_vitals = []
-    for enc in icu_encs:
-        token  = ref_id(enc.subject)
-        vitals = await repo.latest_vitals(token) if token else []
-        icu_with_vitals.append({"encounter": enc, "vitals": vitals, "bed": _bed_for(enc)})
+    # Vitals for every patient in ONE Fabric read instead of one call per patient.
+    # This used to be two sequential `for` loops each awaiting repo.latest_vitals(),
+    # so cost was 1 Fabric call per admission, hospital-wide and uncapped -- ~300
+    # serial calls (~33s) on a 300-bed hospital, and 85% of one live flow's total
+    # Fabric traffic. The escalation sweep in particular walks EVERY active non-ICU
+    # admission, because any ward patient going critical is a candidate.
+    #
+    # Dedup the tokens first: the same patient can appear on several admissions,
+    # and both loops often want the same person.
+    vitals_by_token = await bulk_vitals_observations(
+        tokens_from_encounters([*icu_encs, *non_encs]))
 
-    # Fetch vitals for non-ICU patients and keep only those with critical readings.
-    # Deduplicate by patient token -- same patient across multiple admissions appears once.
+    def _vitals_for(enc) -> list:
+        token = ref_id(enc.subject)
+        return vitals_by_token.get(token, []) if token else []
+
+    icu_with_vitals = [
+        {"encounter": enc, "vitals": _vitals_for(enc), "bed": _bed_for(enc)}
+        for enc in icu_encs
+    ]
+
+    # Keep only non-ICU patients with critical readings. Deduplicate by patient
+    # token -- same patient across multiple admissions appears once.
     escalation_candidates = []
     critical_vital_ids: list[str] = []
     seen_tokens: set[str] = set()
     for enc in non_encs:
         token  = ref_id(enc.subject)
-        vitals = await repo.latest_vitals(token) if token else []
+        vitals = _vitals_for(enc)
         if vitals and is_critical(vitals):
             if token and token in seen_tokens:
                 continue

--- a/agentic-framework/db/fabric.py
+++ b/agentic-framework/db/fabric.py
@@ -11,12 +11,32 @@ Usage:
     await fpost(f"/beds/{bed_id}/status", {"status": "Available"})
 """
 
+import asyncio
 import logging
+import time
 
 import httpx
 from config import settings
 
 logger = logging.getLogger("db.fabric")
+
+
+def _rows(data) -> int:
+    return len(data) if isinstance(data, (list, dict)) else 1
+
+
+def _who() -> str:
+    """Attribute a call to the agent/task that fired it (blank outside a node)."""
+    try:
+        from workflows.graph.exec_context import get_exec_ctx
+        ctx = get_exec_ctx() or {}
+    except Exception:  # noqa: BLE001
+        return ""
+    sid = (ctx.get("session_id") or "")[:8]
+    parts = [p for p in (f"sess={sid}" if sid else "",
+                         f"agent={ctx.get('agent_id')}" if ctx.get("agent_id") else "",
+                         f"task={ctx.get('task')}" if ctx.get("task") else "") if p]
+    return ("  " + " ".join(parts)) if parts else ""
 
 
 def _headers() -> dict:
@@ -36,30 +56,158 @@ def _headers() -> dict:
     return headers
 
 
+# One shared client so connections are pooled and reused across calls. A new
+# client per request opened a fresh connection every time and fell over under
+# light concurrency. Headers stay per-call -- they carry the tenant's X-Org-Id.
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            timeout=httpx.Timeout(20.0, connect=5.0),
+            limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
+        )
+    return _client
+
+
+async def aclose_client() -> None:
+    """Close the shared client (call on worker shutdown)."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+# ── Per-flow read memo ────────────────────────────────────────────────────────
+# Agents re-read the same endpoints constantly within one flow, because nothing
+# shares fetched data between steps: `ta_results` is a function-local dict, and
+# should_run_task() gates on the plan only -- never on "did this task already
+# run". Three measured consequences, all on the same 10-admission dataset:
+#
+#   * discharge.batch_assess_discharges fires 2 GETs x N admissions, and every
+#     re-run of the body costs the full 20 calls again (20 / 20 / 20 over three
+#     passes). HITL interrupts re-run the body from the top (graph.nodes), and
+#     the resume driver loops up to max_passes=8 -> up to 160 calls for 10
+#     admissions.
+#   * pharmacy/lab subagents each re-fetch their own inputs: /pharmacy/orders/
+#     pending and /pharmacy/inventory twice over just two activities.
+#   * per-entity paths (/vitals/latest?patient=, /tasks?admission=) have no bulk
+#     form upstream and no Redis cache, so each one is a live 120-160ms round
+#     trip to a remote host.
+#
+# So: memoize GETs for the lifetime of one drive pass, keyed by the executing
+# session. Scoped per session_id (NOT stored in the exec_context ContextVar --
+# set_exec_ctx() is called per node and overwrites it, which would dedup only
+# within a single agent and miss exactly the cross-agent repeats above).
+#
+# Deliberately NOT a TTL cache: a flow wants one consistent snapshot, and
+# runner._drive clears the memo at the end of every pass, so a resumed flow
+# (which can sit parked for the 30min approval timeout) re-reads live data
+# rather than serving a stale clinical snapshot.
+_flow_memo: dict[str, dict] = {}          # session_id -> {key: (event, box)}
+_MEMO_MAX_ENTRIES = 2000                  # per-session guard against unbounded growth
+
+
+def _memo_session() -> str:
+    """The session whose memo applies, or "" to bypass (outside a flow)."""
+    try:
+        from workflows.graph.exec_context import get_exec_ctx
+        return (get_exec_ctx() or {}).get("session_id") or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _memo_key(path: str, clean: dict) -> tuple:
+    return (path, tuple(sorted((k, str(v)) for k, v in clean.items())))
+
+
+def clear_flow_memo(session_id: str | None = None) -> None:
+    """Drop memoized reads for one session (or all). Called by runner._drive at
+    the end of each pass; safe to call for a session that never cached."""
+    if session_id is None:
+        _flow_memo.clear()
+    else:
+        _flow_memo.pop(session_id, None)
+
+
+def _invalidate_on_write(path: str) -> None:
+    """A write makes this flow's cached reads stale. Drop the whole session's
+    memo rather than guessing which read paths a write affects -- e.g. discharge
+    POSTs an AI note and later activities re-read the same admission, and
+    /beds/{id}/status changes what every /beds* filter returns. Coarse, but a
+    wrong-but-fast snapshot is the failure mode worth avoiding here."""
+    sid = _memo_session()
+    if sid:
+        _flow_memo.pop(sid, None)
+
+
 async def fget(path: str, **params):
     url = settings.fabric_base_url.rstrip("/") + path
     clean = {k: v for k, v in params.items() if v is not None}
-    async with httpx.AsyncClient(timeout=20.0) as c:
-        r = await c.get(url, params=clean, headers=_headers())
-        r.raise_for_status()
-        data = r.json()
-        logger.info("GET %s  -> %d item(s)", path, len(data) if isinstance(data, list) else 1)
-        return data
+    filt = f"?[{','.join(sorted(clean))}]" if clean else ""  # filter keys only, no PII values
+
+    sid = _memo_session()
+    if not sid:                      # outside a flow (poller, advisory scan, API route)
+        return await _fget_live(path, url, clean, filt)
+
+    memo = _flow_memo.setdefault(sid, {})
+    key = _memo_key(path, clean)
+    hit = memo.get(key)
+    if hit is not None:
+        event, box = hit
+        if not event.is_set():
+            # Single-flight: an identical GET is already in flight for this flow
+            # (the agents fan out with asyncio.gather, so this is the common
+            # case, not a rarity). Wait for it instead of duplicating the fetch.
+            await event.wait()
+        if "data" in box:
+            logger.info("GET %s%s -> memo hit%s", path, filt, _who())
+            return box["data"]
+        raise box["exc"]             # the in-flight fetch failed; surface it to this caller too
+
+    event, box = asyncio.Event(), {}
+    if len(memo) < _MEMO_MAX_ENTRIES:
+        memo[key] = (event, box)
+    try:
+        box["data"] = await _fget_live(path, url, clean, filt)
+        return box["data"]
+    except BaseException as exc:
+        # Do not memoize failures -- a retry should get a real attempt. Keep the
+        # entry only long enough to hand this error to anyone already waiting.
+        box["exc"] = exc
+        memo.pop(key, None)
+        raise
+    finally:
+        event.set()
+
+
+async def _fget_live(path: str, url: str, clean: dict, filt: str):
+    t0 = time.perf_counter()
+    r = await _get_client().get(url, params=clean, headers=_headers())
+    r.raise_for_status()
+    data = r.json()
+    logger.info("GET %s%s -> %d row(s) %dms%s",
+                path, filt, _rows(data), int((time.perf_counter() - t0) * 1000), _who())
+    return data
 
 
 async def fpost(path: str, body: dict | None = None):
     url = settings.fabric_base_url.rstrip("/") + path
-    logger.info("POST %s", path)
-    async with httpx.AsyncClient(timeout=20.0) as c:
-        r = await c.post(url, json=body, headers=_headers())
-        r.raise_for_status()
-        return r.json()
+    t0 = time.perf_counter()
+    r = await _get_client().post(url, json=body, headers=_headers())
+    r.raise_for_status()
+    _invalidate_on_write(path)
+    logger.info("POST %s %dms%s", path, int((time.perf_counter() - t0) * 1000), _who())
+    return r.json()
 
 
 async def fpatch(path: str, body: dict | None = None):
     url = settings.fabric_base_url.rstrip("/") + path
-    logger.info("PATCH %s", path)
-    async with httpx.AsyncClient(timeout=20.0) as c:
-        r = await c.patch(url, json=body, headers=_headers())
-        r.raise_for_status()
-        return r.json()
+    t0 = time.perf_counter()
+    r = await _get_client().patch(url, json=body, headers=_headers())
+    r.raise_for_status()
+    _invalidate_on_write(path)
+    logger.info("PATCH %s %dms%s", path, int((time.perf_counter() - t0) * 1000), _who())
+    return r.json()

--- a/agentic-framework/db/hasura.py
+++ b/agentic-framework/db/hasura.py
@@ -1,4 +1,5 @@
-﻿import json
+﻿import asyncio
+import json
 import logging
 import re
 import httpx
@@ -1782,6 +1783,52 @@ class HasuraClient:
 
     async def get_latest_vitals(self, patient_token: str) -> dict | None:
         return await fget("/vitals/latest", patient=patient_token)
+
+    async def get_latest_vitals_bulk(self, patient_tokens: list[str]) -> dict[str, dict]:
+        """{token: latest vitals} for many patients in ONE Fabric call.
+
+        Replaces N calls to /vitals/latest. Fabric can only do this as an
+        unfiltered read (the upstream FHIR server scopes Observations by a single
+        `patient` param and supports no batch form), and that read cannot be
+        paged -- so it reports `complete`. When it comes back False the map is a
+        prefix and we must not present it as the whole truth: fall back to
+        per-patient reads for whatever is missing, which is slow but correct.
+        Vitals decide escalation, so a silently-absent critical reading is the
+        one outcome worth paying for."""
+        if not patient_tokens:
+            return {}
+        try:
+            resp = await fget("/vitals/latest-bulk", patients=",".join(patient_tokens))
+        except Exception as exc:  # noqa: BLE001 -- bulk is an optimization, never a hard dep
+            logger.warning("bulk vitals failed, falling back to per-patient: %s", exc)
+            resp = None
+
+        out: dict[str, dict] = {}
+        complete = False
+        if isinstance(resp, dict):
+            out = {t: v for t, v in (resp.get("vitals") or {}).items() if v}
+            complete = bool(resp.get("complete"))
+
+        missing = [t for t in patient_tokens if t not in out]
+        # A truncated read means "absent" is not trustworthy, so re-check every
+        # missing token. A complete read means absent == genuinely no vitals, and
+        # re-fetching those would put back the N calls this exists to remove.
+        if missing and not complete:
+            logger.warning("bulk vitals incomplete -- per-patient fallback for %d token(s)",
+                           len(missing))
+            sem = asyncio.Semaphore(10)
+
+            async def _one(tok: str) -> None:
+                async with sem:
+                    try:
+                        v = await fget("/vitals/latest", patient=tok)
+                        if v:
+                            out[tok] = v
+                    except Exception:  # noqa: BLE001
+                        pass
+
+            await asyncio.gather(*[_one(t) for t in missing])
+        return out
 
     async def get_vital_observation(self, observation_id: str) -> dict | None:
         try:

--- a/agentic-framework/fhirgw/extensions.py
+++ b/agentic-framework/fhirgw/extensions.py
@@ -52,8 +52,23 @@ def ext_string(url: str, value) -> dict:
     return {"url": url, "valueString": str(value)}
 
 
-def ext_int(url: str, value) -> dict:
-    return {"url": url, "valueInteger": int(value)}
+def ext_int(url: str, value) -> dict | None:
+    """valueInteger, tolerant of raw HIS pass-throughs.
+
+    Rows reaching us through the Redis projection are raw HIS values: numbers
+    arrive as strings ("1") and nulls as the literal string "NULL" (same shape
+    the OT rules handle in graph.advisory_evaluators._ot_val). A bare int() on
+    "NULL" raised ValueError inside the Location mapper, which killed the whole
+    ICU agent -- every available-ICU-bed row carries floor="NULL". An
+    unparseable value means "not reported", so the extension is omitted: the
+    caller drops a None extension rather than emitting a bogus 0.
+    """
+    if value is None or str(value).strip().upper() in ("", "NULL", "NONE"):
+        return None
+    try:
+        return {"url": url, "valueInteger": int(float(str(value).strip()))}
+    except (TypeError, ValueError):
+        return None
 
 
 def ext_bool(url: str, value) -> dict:
@@ -62,6 +77,12 @@ def ext_bool(url: str, value) -> dict:
 
 def ext_decimal(url: str, value) -> dict:
     return {"url": url, "valueDecimal": value}
+
+
+def append_ext(exts: list, ext: dict | None) -> None:
+    """Append an extension, skipping the builders' None ("not reported")."""
+    if ext is not None:
+        exts.append(ext)
 
 
 _VALUE_FIELDS = (

--- a/agentic-framework/fhirgw/mappers/encounter.py
+++ b/agentic-framework/fhirgw/mappers/encounter.py
@@ -66,7 +66,7 @@ def visit_to_fhir(visit: dict) -> Encounter:
     if visit.get("status") is not None:
         exts.append(X.ext_string(X.EXT_VISIT_RAW_STATUS, visit["status"]))
     if visit.get("triage_score") is not None:
-        exts.append(X.ext_int(X.EXT_VISIT_TRIAGE_SCORE, visit["triage_score"]))
+        X.append_ext(exts, X.ext_int(X.EXT_VISIT_TRIAGE_SCORE, visit["triage_score"]))
 
     fhir_status = T.encounter_status_to_fhir(visit.get("status"))
     kwargs: dict = {

--- a/agentic-framework/fhirgw/mappers/location.py
+++ b/agentic-framework/fhirgw/mappers/location.py
@@ -37,9 +37,9 @@ def to_fhir(bed: dict) -> Location:
         if bed.get(key) is not None:
             exts.append(X.ext_string(url, bed[key]))
     if bed.get("proximity") is not None:
-        exts.append(X.ext_int(X.EXT_BED_PROXIMITY, bed["proximity"]))
+        X.append_ext(exts, X.ext_int(X.EXT_BED_PROXIMITY, bed["proximity"]))
     if bed.get("floor") is not None:
-        exts.append(X.ext_int(X.EXT_BED_FLOOR, bed["floor"]))
+        X.append_ext(exts, X.ext_int(X.EXT_BED_FLOOR, bed["floor"]))
     if bed.get("natural_light") is not None:
         exts.append(X.ext_bool(X.EXT_BED_NATURAL_LIGHT, bed["natural_light"]))
     for feat in (bed.get("features") or []):

--- a/agentic-framework/main.py
+++ b/agentic-framework/main.py
@@ -155,6 +155,8 @@ async def lifespan(app: FastAPI):
     flush_langfuse()
     await close_checkpointer()
     await close_redis()
+    from db.fabric import aclose_client
+    await aclose_client()
     logger.info("Shutdown complete")
 
 

--- a/agentic-framework/workflows/graph/runner.py
+++ b/agentic-framework/workflows/graph/runner.py
@@ -426,6 +426,14 @@ async def _drive(graph, payload, config, session_id: str | None = None,
                 return
         logger.exception("session graph errored  config=%s", config.get("configurable"))
     finally:
+        # Drop this pass's memoized Fabric reads (db.fabric._flow_memo). Cleared
+        # per pass, not per flow: a parked flow can sit at an approval for the
+        # 30min reaper timeout, and the next pass must re-read live clinical data
+        # instead of serving the pre-approval snapshot. Within a pass the memo
+        # still collapses the cross-agent and re-execution refetches.
+        if session_id:
+            from db.fabric import clear_flow_memo
+            clear_flow_memo(session_id)
         flush_langfuse()
         if _log_session_id:
             from flow_log import log_session_end

--- a/agentic-framework/workflows/temporal/worker/run_worker.py
+++ b/agentic-framework/workflows/temporal/worker/run_worker.py
@@ -128,6 +128,8 @@ async def main() -> None:
         await worker.run()
     finally:
         flush_langfuse()
+        from db.fabric import aclose_client
+        await aclose_client()
 
 
 if __name__ == "__main__":

--- a/fabric/src/clients/fhir_client.py
+++ b/fabric/src/clients/fhir_client.py
@@ -114,6 +114,20 @@ async def _search(resource_type: str, params: dict) -> list[dict]:
     return [e["resource"] for e in (bundle.get("entry") or []) if e.get("resource")]
 
 
+async def _search_with_total(resource_type: str, params: dict) -> tuple[list[dict], int | None]:
+    """_search, but also returning Bundle.total so a caller can detect truncation.
+
+    Needed because this server has no usable paging: it ignores _offset (the same
+    request with _offset=0 and _offset=100 returns byte-identical results) and
+    emits only a `self` link, never `next`. So an unfiltered search either returns
+    everything or silently returns a prefix -- and total vs len(entry) is the only
+    signal telling the two apart."""
+    bundle = await _get(resource_type, params)
+    rows = [e["resource"] for e in (bundle.get("entry") or []) if e.get("resource")]
+    total = bundle.get("total")
+    return rows, (total if isinstance(total, int) else None)
+
+
 def _parse(model_cls, raw_list: list[dict], label: str) -> list:
     out = []
     for raw in raw_list:
@@ -145,6 +159,12 @@ async def search_locations(params: dict) -> list[Location]:
 
 async def search_observations(params: dict) -> list[Observation]:
     return _parse(Observation, await _search("Observation", params), "Observation")
+
+
+async def search_observations_with_total(params: dict) -> tuple[list[Observation], int | None]:
+    """search_observations + Bundle.total, for the unfiltered bulk vitals read."""
+    raw, total = await _search_with_total("Observation", params)
+    return _parse(Observation, raw, "Observation"), total
 
 
 async def search_organizations(params: dict) -> list[Organization]:

--- a/fabric/src/input_transform/clinical.py
+++ b/fabric/src/input_transform/clinical.py
@@ -16,8 +16,12 @@ while the routes here answer the list, filter and computed questions a per-recor
 different questions.
 """
 
+import logging
+
 from clients import fhir_client as fc
 from input_transform import transform as tx
+
+logger = logging.getLogger("clinical")
 
 PAGE = 200   # DB caps _count at 200
 
@@ -172,6 +176,62 @@ async def latest_vitals(patient_token: str) -> dict | None:
     if not readings:
         return None
     return max(readings, key=lambda r: (r.get("recorded_at") or ""))
+
+
+async def latest_vitals_bulk(tokens: list[str] | None = None) -> dict:
+    """{patient_token: latest vital reading} for many patients in ONE upstream call.
+
+    Why this exists: /vitals/latest is per-patient because `patient` is the only
+    patient-scoping search param the upstream FHIR server advertises (its
+    CapabilityStatement lists exactly patient, category, code, interpretation,
+    _count -- there is no subject, _has, $lastn, $export or batch-Bundle support,
+    all verified 404). Callers that need N patients therefore fired N calls: the
+    ICU agent's escalation sweep runs one per admission, hospital-wide and
+    uncapped, which is the single largest source of Fabric traffic.
+
+    An UNFILTERED vital-signs search is the only bulk read available, and it is a
+    pattern already in use here -- critical_vitals() below does the same thing
+    with an interpretation filter. We group by subject and keep each patient's
+    newest reading, which reproduces latest_vitals() exactly (verified against 27
+    patients: identical id and recorded_at, zero mismatches).
+
+    TRUNCATION is the hazard. This server cannot page: _offset is silently
+    ignored and only a `self` link is returned, never `next`. So if the hospital
+    has more vital Observations than one response carries, we get a prefix with
+    no error -- and a caller would see healthy-looking data for a patient whose
+    critical reading fell off the end. `complete` reports whether Bundle.total
+    matched what we received; when it is False the caller MUST fall back to
+    per-patient reads rather than trust this map.
+
+    Returns {"vitals": {token: reading}, "complete": bool, "total": int|None,
+             "received": int} -- shaped so the truncation signal cannot be
+    ignored by accident the way a bare dict's missing keys would be.
+    """
+    obs, total = await fc.search_observations_with_total(
+        {"category": "vital-signs", "_count": PAGE})
+    received = len(obs)
+    complete = (total is None) or (received >= total)
+    if not complete:
+        logger.warning(
+            "bulk vitals TRUNCATED -- upstream reports total=%s but returned %d "
+            "observations and supports no paging; callers must fall back to "
+            "per-patient reads", total, received)
+
+    latest: dict[str, dict] = {}
+    for group in tx.group_vitals_by_reading(obs).values():
+        r = tx.vital(group)
+        token = (r or {}).get("patient_token")
+        if not r or not token:
+            continue
+        cur = latest.get(token)
+        if cur is None or (r.get("recorded_at") or "") > (cur.get("recorded_at") or ""):
+            latest[token] = r
+
+    if tokens:
+        wanted = set(tokens)
+        latest = {t: v for t, v in latest.items() if t in wanted}
+
+    return {"vitals": latest, "complete": complete, "total": total, "received": received}
 
 
 async def critical_vitals() -> list[dict]:

--- a/fabric/src/runtime/vitals.py
+++ b/fabric/src/runtime/vitals.py
@@ -21,6 +21,30 @@ async def vitals_latest(patient: str = Query(...)):
     return await clinical.latest_vitals(patient)
 
 
+@router.get("/vitals/latest-bulk", summary="Latest vitals for MANY patients in one call")
+async def vitals_latest_bulk(
+    patients: str | None = Query(
+        None, description="Optional comma-separated patient tokens to restrict the "
+                          "result to. Omit for every patient with vitals."),
+):
+    """One upstream read instead of one per patient.
+
+    `patient` is the only patient-scoping search param this upstream FHIR server
+    supports, so /vitals/latest cannot take a list -- callers needing N patients
+    fired N calls. This does a single unfiltered vital-signs search and groups by
+    subject, which is how /vitals/critical already reads.
+
+    The response carries `complete`. It is False when the upstream reported more
+    Observations than it returned (this server ignores _offset and emits no
+    `next` link, so a big hospital can silently get a prefix). On complete=False
+    the caller MUST fall back to per-patient /vitals/latest for the tokens it
+    still needs -- treating a short map as authoritative would hide a patient's
+    critical reading.
+    """
+    toks = [t.strip() for t in patients.split(",") if t.strip()] if patients else None
+    return await clinical.latest_vitals_bulk(toks)
+
+
 @router.get("/vitals/critical", summary="Vitals currently flagged critical, across all patients")
 async def vitals_critical():
     return await clinical.critical_vitals()


### PR DESCRIPTION
…ext_int

Ports the fabric/perf work from hospilot-internal (edb9470..f849202). Five changes that together collapse the request volume one flow generates:

fix(fhirgw): ext_int tolerates raw HIS values instead of crashing. A non-numeric
  value in an integer extension took the whole mapper down; it now degrades.

perf(fabric): memoize Fabric GETs for the lifetime of one drive pass, keyed by
  session. Agents re-read the same endpoints constantly within a flow because
  nothing shares fetched data between steps -- discharge.batch_assess_discharges
  alone fires 2 GETs x N admissions and pays the full cost again on every
  re-run, up to 8 passes. Deliberately not a TTL cache: runner._drive clears the
  memo at the end of each pass, so a flow parked at an approval re-reads live
  clinical data rather than serving a pre-approval snapshot. Writes invalidate
  the session's memo coarsely -- a wrong-but-fast snapshot is the failure mode
  worth avoiding here.

feat(fabric): GET /vitals/latest-bulk with a truncation guard, so vitals for N
  patients is one call instead of N.

perf(agents): ER and ICU sweeps use the bulk endpoint (new agents/_shared/
  vitals_bulk.py) rather than a per-patient round trip each.

Also carried across, because the public tree did not have it: db/fabric.py now uses ONE shared pooled httpx.AsyncClient instead of constructing a fresh client per call. A new client per request opened a new connection every time -- ~44ms of TCP setup on every read against a remote upstream -- and fell over under light concurrency. The memoization commit is written against this version, so porting the memo alone would have meant publishing an adaptation that has never run anywhere.

aclose_client() is wired into both shutdown paths (main.py lifespan and the Temporal worker's finally). These call sites live outside the ported commit range in the internal repo, so without them the pooled client would leak on exit here. hospilot-internal already has them; no change needed there.

Not ported: FABRIC_USAGE_REVIEW.txt and scripts/fabric-usage-test.sh. The review names internal hosts, the private repo and a test login; the script carries a default password.

Verified: fabric suite 75 passed; all 14 changed files compile; the ported symbols and the icu/er activity modules import cleanly.

## What does this change?

<!-- One or two sentences. What's different after this PR, and why. -->

## Which service(s)?

- [x] `agentic-framework`
- [x] `fabric`
- [ ] docs / README only

## Testing

<!-- What did you run to confirm this works? `python -m pytest` output, a manual repro
     steps, etc. A PR with no testing notes is harder to review, not faster. -->

## Checklist

- [x] Tests pass locally (`python -m pytest` in the service(s) you touched)
- [x] New behavior has test coverage
- [ ] Scoped to one change — no unrelated reformatting/renaming mixed in
