### PR TITLE
Fix canvas selection re-render loop, header cleanup

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -53,7 +53,6 @@ export function Header() {
     <header className="relative z-[60] grid grid-cols-[1fr_auto_1fr] items-center px-5 py-0 border-b border-[var(--border)] bg-[var(--bg-base)] flex-shrink-0 h-14">
       {/* Logo */}
       <div className="flex items-center gap-2.5 col-start-1 justify-self-start min-w-0">
-        <img src="/carer.png" alt="Carer" className="h-6 w-auto flex-shrink-0" />
         <div className="min-w-0">
           <div className="text-sm font-bold text-slate-100 leading-tight truncate">Hospilot</div>
           <div className="text-[10px] text-slate-500 leading-tight truncate hidden lg:block">Hospital AI Command Center</div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -416,7 +416,7 @@ export function Sidebar() {
                 {reorchestrateLoading && (
                   <div className="flex items-center gap-2 px-1 py-1 text-xs text-blue-400">
                     <Loader2 size={11} className="animate-spin flex-shrink-0" />
-                    <span>Re-orchestrating pipeline…</span>
+                    <span>Re-orchestrating workflow…</span>
                   </div>
                 )}
               </div>

--- a/web/src/components/canvas/PipelineCanvas.tsx
+++ b/web/src/components/canvas/PipelineCanvas.tsx
@@ -264,6 +264,15 @@ export function PipelineCanvas() {
 		[setNodes, setStoreNodes]
 	)
 
+	// Stable reference -- ReactFlow's SelectionListener re-runs its internal effect
+	// whenever this callback's identity changes, so an inline arrow here (a fresh
+	// function every render) makes it refire every render too, which around here
+	// snowballs into "Maximum update depth exceeded".
+	const onSelectionChange = useCallback(
+		({ nodes: sel }: { nodes: Node[] }) => setSelectedIds(sel.map((n) => n.id)),
+		[]
+	)
+
 	// ── Drag-and-drop from palette ───────────────────────────────────────────
 	const onDragOver = useCallback((event: React.DragEvent) => {
 		event.preventDefault()
@@ -546,7 +555,7 @@ export function PipelineCanvas() {
 				nodesConnectable={isEditing}
 				elementsSelectable={!isRunning}
 				deleteKeyCode={['Delete', 'Backspace']}
-				onSelectionChange={({ nodes: sel }) => setSelectedIds(sel.map((n) => n.id))}
+				onSelectionChange={onSelectionChange}
 				onInit={(instance) => { rfRef.current = instance }}
 				fitView
 				fitViewOptions={{ padding: 0.2, minZoom: 0.5 }}
@@ -803,7 +812,7 @@ export function PipelineCanvas() {
 				<div className="absolute inset-0 z-20 flex items-center justify-center bg-black/40 backdrop-blur-sm pointer-events-none">
 					<div className="flex items-center gap-3 px-5 py-3 rounded-2xl bg-[var(--bg-overlay-base)] border border-blue-500/40 shadow-2xl">
 						<Loader2 size={14} className="text-blue-400 animate-spin flex-shrink-0" />
-						<span className="text-xs text-blue-300 font-semibold">Re-orchestrating pipeline…</span>
+						<span className="text-xs text-blue-300 font-semibold">Re-orchestrating workflow…</span>
 					</div>
 				</div>
 			)}


### PR DESCRIPTION
## Summary
- Fixes a real bug hit while executing a workflow: "Maximum update depth exceeded"
  in PipelineCanvas. `onSelectionChange` was passed as an inline arrow function to
  `<ReactFlow>` — a fresh reference every render. ReactFlow's SelectionListener
  re-runs its internal effect whenever that callback's identity changes, so it
  refired every render, which snowballed during execution (frequent live status
  updates re-rendering the canvas). Memoized it with `useCallback`, matching every
  other handler already in the file.
- Drops the Carer logo from the app header, keeping just the Hospilot wordmark.
- Renames "Re-orchestrating pipeline..." to "Re-orchestrating workflow..." in the
  canvas overlay and sidebar loading indicator, matching the "workflow" wording
  used everywhere else in the UI