### PR TITLE
fix(agents): merge the duplicate `pharmacy_agent` agent-card entry

### DIFF
--- a/agentic-framework/api/routes/agents.py
+++ b/agentic-framework/api/routes/agents.py
@@ -66,13 +66,6 @@ _AGENT_CARDS = {
         "capabilities": {"streaming": False, "pushNotifications": False},
         "skills": [{"id": "discharge_readiness", "name": "Discharge Readiness Check"}],
     },
-    "pharmacy_agent": {
-        "name": "Pharmacy Agent",
-        "description": "Checks drug inventory for critical shortages.",
-        "version": "1.0.0",
-        "capabilities": {"streaming": False, "pushNotifications": False},
-        "skills": [{"id": "stock_monitor", "name": "Drug Stock Monitor"}],
-    },
     "ot_agent": {
         "name": "OT Scheduling Agent",
         "description": "Reviews scheduled OT cases against post-op bed availability and flags conflicts.",
@@ -147,10 +140,11 @@ _AGENT_CARDS = {
     },
     "pharmacy_agent": {
         "name": "Pharmacy Agent",
-        "description": "Manages pharmacy operations: dispensing queue, STAT order prioritisation, drug interactions, substitution management, controlled drug tracking, and capacity forecasting.",
+        "description": "Manages pharmacy operations: drug inventory and critical shortages, dispensing queue, STAT order prioritisation, drug interactions, substitution management, controlled drug tracking, and capacity forecasting.",
         "version": "1.0.0",
         "capabilities": {"streaming": False, "pushNotifications": False},
         "skills": [
+            {"id": "stock_monitor",       "name": "Drug Stock Monitor"},
             {"id": "dispensing_queue",    "name": "Dispensing Queue"},
             {"id": "drug_interactions",   "name": "Drug Interactions"},
             {"id": "controlled_drugs",    "name": "Controlled Drug Tracking"},


### PR DESCRIPTION
## Problem

`_AGENT_CARDS` in `agentic-framework/api/routes/agents.py` defines the key
`"pharmacy_agent"` twice — once at line 69 and again at line 148:

```python
    "pharmacy_agent": {                                    # line 69
        "name": "Pharmacy Agent",
        "description": "Checks drug inventory for critical shortages.",
        ...
        "skills": [{"id": "stock_monitor", "name": "Drug Stock Monitor"}],
    },
    ...
    "pharmacy_agent": {                                    # line 148
        "name": "Pharmacy Agent",
        "description": "Manages pharmacy operations: dispensing queue, ...",
        ...
        "skills": [
            {"id": "dispensing_queue",    "name": "Dispensing Queue"},
            {"id": "drug_interactions",   "name": "Drug Interactions"},
            {"id": "controlled_drugs",    "name": "Controlled Drug Tracking"},
        ],
    },
```

In a dict literal the later binding wins, so the first entry is discarded at
import time and the `stock_monitor` / "Drug Stock Monitor" skill never reaches
`GET /agents/{agent_id}/card`.

That skill is not stale, though — the pharmacy agent still runs it:

- `workflows/planner.py` lists `SubAgent('sa_stock_monitor', 'Stock Monitor', ...)`
  as the **first** sub-agent under `'pharmacy_agent'`, described as "Reviews current
  medication stock levels and flags drugs running low";
- `agents/_shared/manifest.py` keeps `ta_stock_monitor` in `pharmacy_agent`'s
  `context_fields`, and describes the agent as "Drug inventory levels, critical
  shortage alerts, order tracking";
- `workflows/graph/agents/simple.py` and `workflows/unified_executor.py` both
  dispatch through `sa_stock_monitor`.

So the agent does stock monitoring; its card just stopped advertising it.

`pyflakes` flags the duplicate on `main`:

```
agentic-framework/api/routes/agents.py:69:5:  dictionary key 'pharmacy_agent' repeated with different values
agentic-framework/api/routes/agents.py:148:5: dictionary key 'pharmacy_agent' repeated with different values
```

## Fix

Merge the two literals into one, keeping the surviving (richer) entry in place:

- drop the shadowed block at line 69;
- prepend `{"id": "stock_monitor", "name": "Drug Stock Monitor"}` to its skills;
- fold the inventory/shortage wording into its description.

After the change `_AGENT_CARDS["pharmacy_agent"]["skills"]` is:

```python
[
    {"id": "stock_monitor",       "name": "Drug Stock Monitor"},
    {"id": "dispensing_queue",    "name": "Dispensing Queue"},
    {"id": "drug_interactions",   "name": "Drug Interactions"},
    {"id": "controlled_drugs",    "name": "Controlled Drug Tracking"},
]
```

and `pyflakes` reports no duplicate key. Nothing outside the `pharmacy_agent`
entry is touched, and no other card changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
